### PR TITLE
nicer parsing of Iterable notification metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - nothing yet
 
 #### Changed
-- nothing yet
+- no longer tracks push opens from test pushes, proofs
 
 #### Fixed
-- only track a push open from real campaigns
+- no longer tracks push opens from ghost pushes
 
 
 ## [2.0.1](https://github.com/Iterable/iterable-ios-sdk/releases/tag/2.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 #### Added
 - completion handler blocks for all the Iterable APIs
+- class to represent Iterable notification metadata
 
 #### Removed
 - nothing yet
@@ -13,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - nothing yet
 
 #### Fixed
-- nothing yet
+- only track a push open from real campaigns
 
 
 ## [2.0.1](https://github.com/Iterable/iterable-ios-sdk/releases/tag/2.0.1)

--- a/Iterable-iOS-SDK.xcodeproj/project.pbxproj
+++ b/Iterable-iOS-SDK.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		094995471A8588400047E59B /* NSData+Conversion.m in Sources */ = {isa = PBXBuildFile; fileRef = 094995461A8588400047E59B /* NSData+Conversion.m */; };
 		0995DBDD1CFFF7FE00D50F19 /* IterableLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 0995DBDC1CFFF7FE00D50F19 /* IterableLogging.m */; };
 		09C0FC071A1D6D4700D5A86B /* libIterable-iOS-SDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 09C0FBFB1A1D6D4700D5A86B /* libIterable-iOS-SDK.a */; };
+		09CCB9301D07A7EA003EB75D /* IterableNotificationMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 09CCB92F1D07A7EA003EB75D /* IterableNotificationMetadata.m */; };
 		6804B8601AC0F363000A126B /* CommerceItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 6804B85F1AC0F363000A126B /* CommerceItem.m */; };
 		6845F7331AC3831B0043629D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6845F7321AC3831B0043629D /* SystemConfiguration.framework */; };
 		68E32EF61AC21D37000CEBE1 /* CommerceItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 6804B8651AC10426000A126B /* CommerceItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -57,6 +58,8 @@
 		09C0FBFB1A1D6D4700D5A86B /* libIterable-iOS-SDK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libIterable-iOS-SDK.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		09C0FC061A1D6D4700D5A86B /* Iterable-iOS-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Iterable-iOS-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		09C0FC0C1A1D6D4700D5A86B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		09CCB92D1D07A2E9003EB75D /* IterableNotificationMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IterableNotificationMetadata.h; sourceTree = "<group>"; };
+		09CCB92F1D07A7EA003EB75D /* IterableNotificationMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IterableNotificationMetadata.m; sourceTree = "<group>"; };
 		27BFDE60C2FA15EB7F812F46 /* libPods-Iterable-iOS-SDK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Iterable-iOS-SDK.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		50B627639A91F8FD17DE5BDD /* Pods-Iterable-iOS-SDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Iterable-iOS-SDKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Iterable-iOS-SDKTests/Pods-Iterable-iOS-SDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6804B85F1AC0F363000A126B /* CommerceItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommerceItem.m; sourceTree = "<group>"; };
@@ -121,6 +124,8 @@
 				094995461A8588400047E59B /* NSData+Conversion.m */,
 				0995DBDB1CFFF70800D50F19 /* IterableLogging.h */,
 				0995DBDC1CFFF7FE00D50F19 /* IterableLogging.m */,
+				09CCB92D1D07A2E9003EB75D /* IterableNotificationMetadata.h */,
+				09CCB92F1D07A7EA003EB75D /* IterableNotificationMetadata.m */,
 			);
 			path = "Iterable-iOS-SDK";
 			sourceTree = "<group>";
@@ -364,6 +369,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				09CCB9301D07A7EA003EB75D /* IterableNotificationMetadata.m in Sources */,
 				094995471A8588400047E59B /* NSData+Conversion.m in Sources */,
 				093734271A1D701F00C950B6 /* IterableAPI.m in Sources */,
 				6804B8601AC0F363000A126B /* CommerceItem.m in Sources */,

--- a/Iterable-iOS-SDK.xcodeproj/project.pbxproj
+++ b/Iterable-iOS-SDK.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0995DBDD1CFFF7FE00D50F19 /* IterableLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 0995DBDC1CFFF7FE00D50F19 /* IterableLogging.m */; };
 		09C0FC071A1D6D4700D5A86B /* libIterable-iOS-SDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 09C0FBFB1A1D6D4700D5A86B /* libIterable-iOS-SDK.a */; };
 		09CCB9301D07A7EA003EB75D /* IterableNotificationMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 09CCB92F1D07A7EA003EB75D /* IterableNotificationMetadata.m */; };
+		09CCB9321D07BA04003EB75D /* IterableNotificationMetadataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 09CCB9311D07BA04003EB75D /* IterableNotificationMetadataTests.m */; };
 		6804B8601AC0F363000A126B /* CommerceItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 6804B85F1AC0F363000A126B /* CommerceItem.m */; };
 		6845F7331AC3831B0043629D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6845F7321AC3831B0043629D /* SystemConfiguration.framework */; };
 		68E32EF61AC21D37000CEBE1 /* CommerceItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 6804B8651AC10426000A126B /* CommerceItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -60,6 +61,7 @@
 		09C0FC0C1A1D6D4700D5A86B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		09CCB92D1D07A2E9003EB75D /* IterableNotificationMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IterableNotificationMetadata.h; sourceTree = "<group>"; };
 		09CCB92F1D07A7EA003EB75D /* IterableNotificationMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IterableNotificationMetadata.m; sourceTree = "<group>"; };
+		09CCB9311D07BA04003EB75D /* IterableNotificationMetadataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IterableNotificationMetadataTests.m; sourceTree = "<group>"; };
 		27BFDE60C2FA15EB7F812F46 /* libPods-Iterable-iOS-SDK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Iterable-iOS-SDK.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		50B627639A91F8FD17DE5BDD /* Pods-Iterable-iOS-SDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Iterable-iOS-SDKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Iterable-iOS-SDKTests/Pods-Iterable-iOS-SDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6804B85F1AC0F363000A126B /* CommerceItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommerceItem.m; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 				09C0FC0B1A1D6D4700D5A86B /* Supporting Files */,
 				091489E11CF6986900482D82 /* IterableAPITests.m */,
 				091489E71CF6AC1800482D82 /* CommerceItemTests.m */,
+				09CCB9311D07BA04003EB75D /* IterableNotificationMetadataTests.m */,
 			);
 			path = "Iterable-iOS-SDKTests";
 			sourceTree = "<group>";
@@ -382,6 +385,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				091489E21CF6986900482D82 /* IterableAPITests.m in Sources */,
+				09CCB9321D07BA04003EB75D /* IterableNotificationMetadataTests.m in Sources */,
 				091489E81CF6AC1800482D82 /* CommerceItemTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Iterable-iOS-SDK/IterableNotificationMetadata.h
+++ b/Iterable-iOS-SDK/IterableNotificationMetadata.h
@@ -1,0 +1,82 @@
+//
+//  IterableNotification.h
+//  Iterable-iOS-SDK
+//
+//  Created by Ilya Brin on 6/7/16.
+//  Copyright © 2016 Iterable. All rights reserved.
+//
+
+@import Foundation;
+
+// all params are nonnull, unless annotated otherwise
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ `IterableNotificationMetadata` represents the metadata in an Iterable push notification
+ */
+@interface IterableNotificationMetadata : NSObject
+
+////////////////////
+/// @name Properties
+////////////////////
+
+/**
+ The campaignId of this notification
+ */
+@property(nonatomic, readonly, copy) NSNumber *campaignId;
+
+/**
+ The templateId of this notification
+ */
+@property(nonatomic, readonly, copy) NSNumber *templateId;
+
+/**
+ Whether this notification is a ghost push
+ */
+@property(nonatomic, readonly) BOOL isGhostPush;
+
+//////////////////////////////////////////////////
+/// @name Creating an IterableNotificationMetadata
+//////////////////////////////////////////////////
+
+/**
+ @method
+ 
+ @abstract  Creates an `IterableNotificationMetadata` from a push payload
+ 
+ @param userInfo  The notification payload
+ 
+ @return    an instance of `IterableNotificationMetadata` with the specified properties; `nil` if this isn't an Iterable notification
+ 
+ @warning   `metadataFromLaunchOptions` will return `nil` if `userInfo` isn't an Iterable notification
+ */
++ (nullable instancetype)metadataFromLaunchOptions:(NSDictionary *)userInfo;
+
+///////////////////////////
+/// @name Utility functions
+///////////////////////////
+
+/**
+ @method
+ 
+ @return `YES` if this push is a `proof` push; `NO` otherwise
+ */
+- (BOOL)isProof;
+
+/**
+ @method
+ 
+ @return `YES` if this is a test push; `NO` otherwise
+ */
+- (BOOL)isTestPush;
+
+/**
+ @method
+ 
+ @return `YES` if this is a non-ghost, non-proof, non-test real send; `NO` otherwise
+ */
+- (BOOL)isRealCampaignNotification;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Iterable-iOS-SDK/IterableNotificationMetadata.m
+++ b/Iterable-iOS-SDK/IterableNotificationMetadata.m
@@ -85,17 +85,17 @@ static NSString *const IsGhostPushField = @"isGhostPush";
 
 // documented in IterableNotification.h
 - (BOOL)isProof {
-    return _campaignId == 0 && _templateId != 0;
+    return _campaignId.integerValue == 0 && _templateId.integerValue != 0;
 }
 
 // documented in IterableNotification.h
 - (BOOL)isTestPush {
-    return _campaignId == 0 && _templateId == 0;
+    return _campaignId.integerValue == 0 && _templateId.integerValue == 0;
 }
 
 // documented in IterableNotification.h
 - (BOOL)isRealCampaignNotification {
-    return !([self isProof] || [self isTestPush] || _isGhostPush);
+    return !(_isGhostPush || [self isProof] || [self isTestPush]);
 }
 
 @end

--- a/Iterable-iOS-SDK/IterableNotificationMetadata.m
+++ b/Iterable-iOS-SDK/IterableNotificationMetadata.m
@@ -39,7 +39,7 @@ static NSString *const IsGhostPushField = @"isGhostPush";
     if (userInfo && userInfo[MetadataField]) {
         id pushData = userInfo[MetadataField];
         return [pushData isKindOfClass:[NSDictionary class]]
-            && [pushData[CampaignIdField] isKindOfClass:[NSNumber class]]
+            && (pushData[CampaignIdField] ? [pushData[CampaignIdField] isKindOfClass:[NSNumber class]] : YES) // campaignId doesn't have to be there (because of proofs)
             && [pushData[TemplateIdField] isKindOfClass:[NSNumber class]]
             && [pushData[IsGhostPushField] isKindOfClass:[NSNumber class]];
     } else {
@@ -62,8 +62,8 @@ static NSString *const IsGhostPushField = @"isGhostPush";
 {
     if (self = [super init]) {
         NSDictionary *pushData = userInfo[MetadataField];
+        _campaignId = pushData[CampaignIdField] ? pushData[CampaignIdField] : @0;
         _templateId = pushData[TemplateIdField];
-        _campaignId = pushData[CampaignIdField];
         _isGhostPush = [pushData[IsGhostPushField] boolValue];
     }
     return self;

--- a/Iterable-iOS-SDKTests/IterableNotificationMetadataTests.m
+++ b/Iterable-iOS-SDKTests/IterableNotificationMetadataTests.m
@@ -47,14 +47,6 @@
                                              }
                                      },
                                  
-                                 // no "campaignId"
-                                 @{
-                                     @"itbl": @{
-                                             @"templateId": @0,
-                                             @"isGhostPush": @NO
-                                             }
-                                     },
-                                 
                                  // "campaignId" not a number
                                  @{
                                      @"itbl": @{
@@ -126,6 +118,22 @@
     NSDictionary *payload = @{
                               @"itbl": @{
                                       @"campaignId": @0,
+                                      @"templateId": @777,
+                                      @"isGhostPush": @NO
+                                      }
+                              };
+    IterableNotificationMetadata *metadata = [IterableNotificationMetadata metadataFromLaunchOptions:payload];
+    XCTAssertEqual(metadata.campaignId, @0);
+    XCTAssertEqual(metadata.templateId, @777);
+    XCTAssertFalse(metadata.isGhostPush);
+    XCTAssertTrue([metadata isProof]);
+    XCTAssertFalse([metadata isTestPush]);
+    XCTAssertFalse([metadata isRealCampaignNotification]);
+}
+
+- (void)testValidProofPayloadNoCampaignId {
+    NSDictionary *payload = @{
+                              @"itbl": @{
                                       @"templateId": @777,
                                       @"isGhostPush": @NO
                                       }

--- a/Iterable-iOS-SDKTests/IterableNotificationMetadataTests.m
+++ b/Iterable-iOS-SDKTests/IterableNotificationMetadataTests.m
@@ -1,0 +1,189 @@
+//
+//  IterableNotificationMetadataTests.m
+//  Iterable-iOS-SDK
+//
+//  Created by Ilya Brin on 6/7/16.
+//  Copyright © 2016 Iterable. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "IterableNotificationMetadata.h"
+
+@interface IterableNotificationMetadataTests : XCTestCase
+
+@end
+
+@implementation IterableNotificationMetadataTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testInvalidPayloads {
+    NSArray *invalidPayloads = @[
+                                 // no "itbl"
+                                 @{},
+                                 
+                                 // no "isGhostPush"
+                                 @{
+                                     @"itbl": @{
+                                             @"campaignId": @0,
+                                             @"templateId": @0
+                                             }
+                                     },
+                                 
+                                 // no "templateId"
+                                 @{
+                                     @"itbl": @{
+                                             @"campaignId": @0,
+                                             @"isGhostPush": @NO
+                                             }
+                                     },
+                                 
+                                 // no "campaignId"
+                                 @{
+                                     @"itbl": @{
+                                             @"templateId": @0,
+                                             @"isGhostPush": @NO
+                                             }
+                                     },
+                                 
+                                 // "campaignId" not a number
+                                 @{
+                                     @"itbl": @{
+                                             @"campaignId": @"hello",
+                                             @"templateId": @0,
+                                             @"isGhostPush": @NO
+                                             }
+                                     },
+                                 
+                                 // "templateId" not a number
+                                 @{
+                                     @"itbl": @{
+                                             @"campaignId": @0,
+                                             @"templateId": @"world",
+                                             @"isGhostPush": @NO
+                                             }
+                                     },
+                                 
+                                 // "isGhostPush" not a number (that represents a BOOL; all numbers represent BOOLs though). 0 = NO, everything else = YES
+                                 @{
+                                     @"itbl": @{
+                                             @"campaignId": @0,
+                                             @"templateId": @0,
+                                             @"isGhostPush": @"lol"
+                                             }
+                                     }
+                                 ];
+    for (NSDictionary *payload in invalidPayloads) {
+        IterableNotificationMetadata *metadata = [IterableNotificationMetadata metadataFromLaunchOptions:payload];
+        XCTAssertNil(metadata);
+    }
+}
+
+- (void)testValidGhostPayload {
+    NSDictionary *payload = @{
+      @"itbl": @{
+              @"campaignId": @666,
+              @"templateId": @777,
+              @"isGhostPush": @YES
+              }
+      };
+    IterableNotificationMetadata *metadata = [IterableNotificationMetadata metadataFromLaunchOptions:payload];
+    XCTAssertEqual(metadata.campaignId, @666);
+    XCTAssertEqual(metadata.templateId, @777);
+    XCTAssertTrue(metadata.isGhostPush);
+    XCTAssertFalse([metadata isProof]);
+    XCTAssertFalse([metadata isTestPush]);
+    XCTAssertFalse([metadata isRealCampaignNotification]);
+}
+
+- (void)testValidRealPayload {
+    NSDictionary *payload = @{
+                              @"itbl": @{
+                                      @"campaignId": @666,
+                                      @"templateId": @777,
+                                      @"isGhostPush": @NO
+                                      }
+                              };
+    IterableNotificationMetadata *metadata = [IterableNotificationMetadata metadataFromLaunchOptions:payload];
+    XCTAssertEqual(metadata.campaignId, @666);
+    XCTAssertEqual(metadata.templateId, @777);
+    XCTAssertFalse(metadata.isGhostPush);
+    XCTAssertFalse([metadata isProof]);
+    XCTAssertFalse([metadata isTestPush]);
+    XCTAssertTrue([metadata isRealCampaignNotification]);
+}
+
+- (void)testValidProofPayload {
+    NSDictionary *payload = @{
+                              @"itbl": @{
+                                      @"campaignId": @0,
+                                      @"templateId": @777,
+                                      @"isGhostPush": @NO
+                                      }
+                              };
+    IterableNotificationMetadata *metadata = [IterableNotificationMetadata metadataFromLaunchOptions:payload];
+    XCTAssertEqual(metadata.campaignId, @0);
+    XCTAssertEqual(metadata.templateId, @777);
+    XCTAssertFalse(metadata.isGhostPush);
+    XCTAssertTrue([metadata isProof]);
+    XCTAssertFalse([metadata isTestPush]);
+    XCTAssertFalse([metadata isRealCampaignNotification]);
+}
+
+- (void)testValidTestPayload {
+    NSDictionary *payload = @{
+                              @"itbl": @{
+                                      @"campaignId": @0,
+                                      @"templateId": @0,
+                                      @"isGhostPush": @NO
+                                      }
+                              };
+    IterableNotificationMetadata *metadata = [IterableNotificationMetadata metadataFromLaunchOptions:payload];
+    XCTAssertEqual(metadata.campaignId, @0);
+    XCTAssertEqual(metadata.templateId, @0);
+    XCTAssertFalse(metadata.isGhostPush);
+    XCTAssertFalse([metadata isProof]);
+    XCTAssertTrue([metadata isTestPush]);
+    XCTAssertFalse([metadata isRealCampaignNotification]);
+}
+
+- (void)testDeserializedFromIterableJson {
+    NSString *jsonGhostPush = @"{\"itbl\":{\"campaignId\":666,\"templateId\":777,\"isGhostPush\":true}}";
+    id objGhostPush = [NSJSONSerialization
+                 JSONObjectWithData:[jsonGhostPush dataUsingEncoding:NSUTF8StringEncoding]
+                 options:0
+                 error:nil];
+    NSDictionary *expectedGhostPush = @{
+                               @"itbl": @{
+                                       @"campaignId": @666,
+                                       @"templateId": @777,
+                                       @"isGhostPush": @YES
+                                       }
+                               };
+    XCTAssertEqualObjects(objGhostPush, expectedGhostPush);
+    
+    NSString *jsonReal = @"{\"itbl\":{\"campaignId\":666,\"templateId\":777,\"isGhostPush\":false}}";
+    id objReal = [NSJSONSerialization
+                       JSONObjectWithData:[jsonReal dataUsingEncoding:NSUTF8StringEncoding]
+                       options:0
+                       error:nil];
+    NSDictionary *expectedReal = @{
+                                        @"itbl": @{
+                                                @"campaignId": @666,
+                                                @"templateId": @777,
+                                                @"isGhostPush": @NO
+                                                }
+                                        };
+    XCTAssertEqualObjects(objReal, expectedReal);
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -120,6 +120,24 @@ No | N/A | Yes | `application:didFinishLaunchingWithOptions:` | On Notification 
 
 For more information about local and remote notifications, and which callbacks will be called under which circumstances, see [Local and Remote Notifications in Depth](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/WhatAreRemoteNotif.html#//apple_ref/doc/uid/TP40008194-CH102-SW1).
 
+#### Iterable Notifications
+
+All notifications from Iterable will come with a field called `itbl` in the payload. This field will contain a dictionary of data for Iterable's use. You can access it directly, but you should avoid doing so, as those fields might change. As of now, the fields include
+
+*  `campaignId` - the campaign id (in Iterable). Not relevant for proof and test pushes.
+*  `templateId` - the template id (in Iterable). Not relevant for test pushes.
+*  `isGhostPush` - whether this is a ghost push. See section below on uninstall tracking.
+
+#### Uninstall Tracking
+
+Iterable will track uninstalls with no additional work by you. 
+
+This is implemented by sending a second push notification some time (currently, twelve hours) after the original campaign. If we receive feedback that the device's token is no longer valid, we assign an uninstall to the device, attributing it to the most recent campaign within twelve hours. An "real" campaign send (as opposed to the later "ghost" send) can also trigger recording an uninstall. In this case, if there was no previous campaign within the attribution period, an uninstall will still be tracked, but it will not be attributed to any campaign.
+
+These "ghost" notifications will **not** automatically create a notification on the device. In fact, your application won't even be notified at all, unless you've enabled background mode. If you'd like your application to receive and act on these "ghost" pushes, you can enable background mode (this won't make the notifications show up; it'll just let your app handle them). To do this, go to your target in Xcode, then go to `Capabilities -> Background Modes` and enable `Background fetch` and `Remote notifications`.
+
+After enabling background mode, you will need to implement a different method instead of `application:didReceiveRemoteNotification:`; this method is [application:didReceiveRemoteNotification:fetchCompletionHandler:](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/#//apple_ref/occ/intfm/UIApplicationDelegate/application:didReceiveRemoteNotification:fetchCompletionHandler:). This method, unlike `application:didReceiveRemoteNotification:`, will be called regardless of whether your application is running in the foreground or background. Once you are done, don't forget to call the completion handler with a `UIBackgroundFetchResult`. For more information on background mode notifications, see the `Discussion` under the [documentation for the method](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/#//apple_ref/occ/intfm/UIApplicationDelegate/application:didReceiveRemoteNotification:fetchCompletionHandler:).
+
 # Additional Information
 
 See our [setup guide](http://support.iterable.com/hc/en-us/articles/204780589-Push-Notification-Setup-iOS-and-Android-) for more information.


### PR DESCRIPTION
no longer tracks opens from test pushes, proofs, and ghost pushes
