### PR TITLE
Encodes special characters in query params with percent encoding.

### DIFF
--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -40,7 +40,7 @@ static NSURLSession *urlSession = nil;
 // the API endpoint
 NSString * const endpoint = @"https://api.iterable.com/api/";
 
-NSMutableCharacterSet* subSet;
+NSCharacterSet* subSet;
 
 
 //////////////////////////
@@ -123,13 +123,12 @@ NSMutableCharacterSet* subSet;
  */
 - (NSString *)encodeURLParam:(NSString *)paramValue
 {
-    //Percent encode special characters
     if ([paramValue isKindOfClass:[NSString class]])
     {
         if (subSet == nil) {
-            subSet = [[NSMutableCharacterSet alloc] init];
-            [subSet formUnionWithCharacterSet:[NSCharacterSet URLQueryAllowedCharacterSet]];
-            [subSet removeCharactersInString:@"+"];
+            NSMutableCharacterSet* workingSet = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+            [workingSet removeCharactersInString:@"+"];
+            subSet = [workingSet copy];
         }
         paramValue = [paramValue stringByAddingPercentEncodingWithAllowedCharacters:subSet];
     }

--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -119,7 +119,7 @@ NSCharacterSet* subSet;
  
  @param paramValue The value to encode
  
- @return an `NSString` containing the full URL
+ @return an `NSString` containing the encoded value
  */
 - (NSString *)encodeURLParam:(NSString *)paramValue
 {
@@ -130,10 +130,10 @@ NSCharacterSet* subSet;
             [workingSet removeCharactersInString:@"+"];
             subSet = [workingSet copy];
         }
-        paramValue = [paramValue stringByAddingPercentEncodingWithAllowedCharacters:subSet];
+        return [paramValue stringByAddingPercentEncodingWithAllowedCharacters:subSet];
+    } else {
+        return paramValue;
     }
-    
-    return paramValue;
 }
 
 /**

--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -98,12 +98,21 @@ NSString * const endpoint = @"https://api.iterable.com/api/";
  */
 - (NSURL *)getUrlForGetAction:(NSString *)action withArgs:(NSDictionary *)args
 {
-    NSString *urlCombined = [NSString stringWithFormat:@"%@%@?api_key=%@", endpoint, action, self.apiKey];
-    //updated this to take in a dictionary are parse values
     
+    
+    NSString *urlCombined = [NSString stringWithFormat:@"%@%@?api_key=%@", endpoint, action, self.apiKey];
     
     for (NSString* paramKey in args) {
         NSString* paramValue = args[paramKey];
+
+        //Percent encode special characters
+        NSMutableCharacterSet* subSet = [[NSMutableCharacterSet alloc] init];
+        [subSet formUnionWithCharacterSet:[NSCharacterSet URLQueryAllowedCharacterSet]];
+        [subSet removeCharactersInString:@"+"];
+        if ([paramValue isKindOfClass:[NSString class]])
+        {
+            paramValue = [paramValue stringByAddingPercentEncodingWithAllowedCharacters:subSet];
+        }
         
         NSString *params = [NSString stringWithFormat:@"&%@=%@", paramKey, paramValue];
         urlCombined = [urlCombined stringByAppendingString:params];

--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -40,6 +40,8 @@ static NSURLSession *urlSession = nil;
 // the API endpoint
 NSString * const endpoint = @"https://api.iterable.com/api/";
 
+NSMutableCharacterSet* subSet;
+
 
 //////////////////////////
 /// @name Internal methods
@@ -98,27 +100,41 @@ NSString * const endpoint = @"https://api.iterable.com/api/";
  */
 - (NSURL *)getUrlForGetAction:(NSString *)action withArgs:(NSDictionary *)args
 {
-    
-    
     NSString *urlCombined = [NSString stringWithFormat:@"%@%@?api_key=%@", endpoint, action, self.apiKey];
     
     for (NSString* paramKey in args) {
         NSString* paramValue = args[paramKey];
-
-        //Percent encode special characters
-        NSMutableCharacterSet* subSet = [[NSMutableCharacterSet alloc] init];
-        [subSet formUnionWithCharacterSet:[NSCharacterSet URLQueryAllowedCharacterSet]];
-        [subSet removeCharactersInString:@"+"];
-        if ([paramValue isKindOfClass:[NSString class]])
-        {
-            paramValue = [paramValue stringByAddingPercentEncodingWithAllowedCharacters:subSet];
-        }
         
-        NSString *params = [NSString stringWithFormat:@"&%@=%@", paramKey, paramValue];
+        NSString *params = [NSString stringWithFormat:@"&%@=%@", paramKey, [self encodeURLParam:paramValue]];
         urlCombined = [urlCombined stringByAppendingString:params];
     }
     
     return [NSURL URLWithString:urlCombined];
+}
+
+/**
+ @method
+ 
+ @abstract Percent encodes the url query parameters
+ 
+ @param paramValue The value to encode
+ 
+ @return an `NSString` containing the full URL
+ */
+- (NSString *)encodeURLParam:(NSString *)paramValue
+{
+    //Percent encode special characters
+    if ([paramValue isKindOfClass:[NSString class]])
+    {
+        if (subSet == nil) {
+            subSet = [[NSMutableCharacterSet alloc] init];
+            [subSet formUnionWithCharacterSet:[NSCharacterSet URLQueryAllowedCharacterSet]];
+            [subSet removeCharactersInString:@"+"];
+        }
+        paramValue = [paramValue stringByAddingPercentEncodingWithAllowedCharacters:subSet];
+    }
+    
+    return paramValue;
 }
 
 /**

--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -40,8 +40,7 @@ static NSURLSession *urlSession = nil;
 // the API endpoint
 NSString * const endpoint = @"https://api.iterable.com/api/";
 
-NSCharacterSet* subSet;
-
+NSCharacterSet* encodedCharacterSet = nil;
 
 //////////////////////////
 /// @name Internal methods
@@ -72,6 +71,13 @@ NSCharacterSet* subSet;
     }
     
     return result;
+}
+
+- (NSCharacterSet *)getEncodedSubset
+{
+    NSMutableCharacterSet* workingSet = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    [workingSet removeCharactersInString:@"+"];
+    return [workingSet copy];
 }
 
 /**
@@ -125,12 +131,7 @@ NSCharacterSet* subSet;
 {
     if ([paramValue isKindOfClass:[NSString class]])
     {
-        if (subSet == nil) {
-            NSMutableCharacterSet* workingSet = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
-            [workingSet removeCharactersInString:@"+"];
-            subSet = [workingSet copy];
-        }
-        return [paramValue stringByAddingPercentEncodingWithAllowedCharacters:subSet];
+        return [paramValue stringByAddingPercentEncodingWithAllowedCharacters:encodedCharacterSet];
     } else {
         return paramValue;
     }
@@ -352,6 +353,8 @@ NSCharacterSet* subSet;
     // the url session doesn't depend on any options/params, so we'll use a singleton that gets created whenever the class is instantiated
     // if it gets instantiated again that's fine; we don't need to reconfigure the session, just keep using the old singleton
     [self createUrlSession];
+    
+    encodedCharacterSet = [self getEncodedSubset];
     
     // Automatically try to track a pushOpen
     if (launchOptions) {


### PR DESCRIPTION
The '+' in our api request needs to be encoded percent encoded. 

Special casing the '+' per https://github.com/daltoniam/SwiftHTTP/issues/178 since '+' is a valid character in URLQueryAllowedCharacterSet.