### PR TITLE
Add (void)clearSharedInstance to IterableAPI.

### DIFF
--- a/Iterable-iOS-SDK/IterableAPI.h
+++ b/Iterable-iOS-SDK/IterableAPI.h
@@ -173,6 +173,14 @@ typedef NS_ENUM(NSInteger, PushServicePlatform) {
  */
 + (nullable IterableAPI *)sharedInstance;
 
+/*!
+ @method
+ 
+ @abstract Sets the previously instantiated singleton instance of the API to nil
+ 
+ */
++ (void)clearSharedInstance;
+
 /////////////////////////////
 /// @name Registering a token
 /////////////////////////////

--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -393,7 +393,9 @@ NSCharacterSet* encodedCharacterSet = nil;
 + (IterableAPI *)sharedInstanceWithApiKey:(NSString *)apiKey andEmail:(NSString *)email launchOptions:(NSDictionary *)launchOptions
 {
     @synchronized (self) {
-        sharedInstance = [[IterableAPI alloc] initWithApiKey:apiKey andEmail:email launchOptions:launchOptions];
+        if(!sharedInstance){
+            sharedInstance = [[IterableAPI alloc] initWithApiKey:apiKey andEmail:email launchOptions:launchOptions];
+        }
         return sharedInstance;
     }
 }
@@ -402,7 +404,9 @@ NSCharacterSet* encodedCharacterSet = nil;
 + (IterableAPI *)sharedInstanceWithApiKey:(NSString *)apiKey andUserId:(NSString *)userId launchOptions:(NSDictionary *)launchOptions
 {
     @synchronized (self) {
-        sharedInstance = [[IterableAPI alloc] initWithApiKey:apiKey andUserId:userId launchOptions:launchOptions];
+        if(!sharedInstance){
+            sharedInstance = [[IterableAPI alloc] initWithApiKey:apiKey andUserId:userId launchOptions:launchOptions];
+        }
         return sharedInstance;
     }
 }

--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -382,25 +382,29 @@ NSCharacterSet* encodedCharacterSet = nil;
 }
 
 // documented in IterableAPI.h
++ (void)clearSharedInstance
+{
+    @synchronized (self) {
+        sharedInstance = nil;
+    }
+}
+
+// documented in IterableAPI.h
 + (IterableAPI *)sharedInstanceWithApiKey:(NSString *)apiKey andEmail:(NSString *)email launchOptions:(NSDictionary *)launchOptions
 {
-    // threadsafe way to create a static singleton https://stackoverflow.com/questions/5720029/create-singleton-using-gcds-dispatch-once-in-objective-c
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
+    @synchronized (self) {
         sharedInstance = [[IterableAPI alloc] initWithApiKey:apiKey andEmail:email launchOptions:launchOptions];
-    });
-    return sharedInstance;
+        return sharedInstance;
+    }
 }
 
 // documented in IterableAPI.h
 + (IterableAPI *)sharedInstanceWithApiKey:(NSString *)apiKey andUserId:(NSString *)userId launchOptions:(NSDictionary *)launchOptions
 {
-    // threadsafe way to create a static singleton https://stackoverflow.com/questions/5720029/create-singleton-using-gcds-dispatch-once-in-objective-c
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
+    @synchronized (self) {
         sharedInstance = [[IterableAPI alloc] initWithApiKey:apiKey andUserId:userId launchOptions:launchOptions];
-    });
-    return sharedInstance;
+        return sharedInstance;
+    }
 }
 
 // documented in IterableAPI.h


### PR DESCRIPTION
The current implementation of IterableAPI does not allow client code to re-initialize a shared instance of IterableAPI once it has already been created. 

We have a use case in which push notifications are managed using an Iterable campaign. We send notifications to both authenticated and anonymous users. Therefore it is necessary for us to register  a device token with a new email address when the user logs in or out. 

This PN simply exposes a static method +(void)clearSharedInstance that will set the static property 'sharedInstance' to nil. Additionally each static initializer (overloads) were updated to use @synchronized to provide thread safety as the use dispatch_once would no longer make sense. 

I believe this change would resolve #36 

If I can clarify further please let me know. Hope this is helpful. 
