### PR TITLE
data must be imported as optional by Swift.

### DIFF
--- a/Iterable-iOS-SDK/IterableAPI.h
+++ b/Iterable-iOS-SDK/IterableAPI.h
@@ -21,7 +21,7 @@ typedef void (^OnSuccessHandler)(NSDictionary *data);
 /**
  The prototype for the completion handler block that gets called when an Iterable call fails
  */
-typedef void (^OnFailureHandler)(NSString *reason, NSData *data);
+typedef void (^OnFailureHandler)(NSString *reason, NSData *_Nullable data);
 
 /**
  Enum representing push platform; apple push notification service, production vs sandbox

--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -244,7 +244,7 @@ NSCharacterSet* encodedCharacterSet = nil;
             if (onFailure != nil) onFailure(@"No data received", data);
         } else if (error != nil) {
             NSString *reason = [NSString stringWithFormat:@"%@", error];
-            if (onFailure != nil) onFailure(reason, data);
+            if (onFailure != nil) onFailure(reason, nil);
         }
     }];
     [task resume];


### PR DESCRIPTION
This pull request fixes a crash that originates when `[IterableAPI sendRequest:onSuccess:onFailure:]` calls `onFailure` `data` with `nil`, thus breaking its bridging contract with Swift.

This is happening because `data` on `onFailureHandler` is specified as [non null](https://github.com/Iterable/iterable-ios-sdk/blob/master/Iterable-iOS-SDK/IterableAPI.h#L14), but this is not guaranteed by [`sendRequest:onSuccess:onFailure`](https://github.com/Iterable/iterable-ios-sdk/blob/master/Iterable-iOS-SDK/IterableAPI.m#L220) since, in the case of an error, `data` (a `_Nullable` type) is passed to [`onFailureHandler`](https://github.com/Iterable/iterable-ios-sdk/blob/master/Iterable-iOS-SDK/IterableAPI.m#L247) triggering the `Data._unconditionallyBridgeFromObjectiveC` crash in `libSwiftFoundation`.

Stack trace summary:

```bash
Crashed: NSOperationQueue 0x1c0237400 (QOS: UNSPECIFIED)
0  libswiftFoundation.dylib       0x106026e4c static Data._unconditionallyBridgeFromObjectiveC(_:) + 34832
1  LeTote                         0x1046f7ae0 thunk (PushNotificationController.swift)
2  IterableSDK                    0x1057e8ef4 __47-[IterableAPI sendRequest:onSuccess:onFailure:]_block_invoke + 424
...
```

I attempted the pull-request to be as unobtrusive as possible, however, the documentation for  [dataTaskWithRequest:completionHandler:](https://developer.apple.com/documentation/foundation/nsurlsession/1407613-datataskwithrequest) states that:

>...If the request fails, the **data parameter is nil** and the error parameter contain information about the failure. If a response from the server is received

This means that `data` is *always* `nil` in the case of an `error`. You should consider changing [if (onFailure != nil) onFailure(reason, data);](https://github.com/Iterable/iterable-ios-sdk/blob/master/Iterable-iOS-SDK/IterableAPI.m#L247) to ` if (onFailure != nil) onFailure(reason, nil);` for clarity.
