### PR TITLE
[ITBL-4446] Handle 4xx and 5xx response codes as errors

### DIFF
--- a/Iterable-iOS-SDK.xcodeproj/project.pbxproj
+++ b/Iterable-iOS-SDK.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		6845F7331AC3831B0043629D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6845F7321AC3831B0043629D /* SystemConfiguration.framework */; };
 		68E32EF61AC21D37000CEBE1 /* CommerceItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 6804B8651AC10426000A126B /* CommerceItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		732C5DFD870D53D1FF92968A /* libPods-Iterable-iOS-SDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A424C23BE698D06646FF675 /* libPods-Iterable-iOS-SDK.a */; };
+		9284CA74206DCA6C00404B74 /* IterableAPIResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9284CA73206DCA6C00404B74 /* IterableAPIResponseTests.m */; };
 		FE48CCB848FD3067A759904D /* libPods-Iterable-iOS-SDKTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 15E14DC3FEF5EE94DFA2424E /* libPods-Iterable-iOS-SDKTests.a */; };
 /* End PBXBuildFile section */
 
@@ -117,6 +118,7 @@
 		6804B8651AC10426000A126B /* CommerceItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CommerceItem.h; sourceTree = "<group>"; };
 		6845F7321AC3831B0043629D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		6A424C23BE698D06646FF675 /* libPods-Iterable-iOS-SDK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Iterable-iOS-SDK.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9284CA73206DCA6C00404B74 /* IterableAPIResponseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IterableAPIResponseTests.m; sourceTree = "<group>"; };
 		C67AA6DFEC454FF39AD12F3F /* Pods-Iterable-iOS-SDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Iterable-iOS-SDK.release.xcconfig"; path = "Pods/Target Support Files/Pods-Iterable-iOS-SDK/Pods-Iterable-iOS-SDK.release.xcconfig"; sourceTree = "<group>"; };
 		DA3D876BD230574973D99AD7 /* Pods-Iterable-iOS-SDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Iterable-iOS-SDK.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Iterable-iOS-SDK/Pods-Iterable-iOS-SDK.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -189,6 +191,7 @@
 			children = (
 				09C0FC0B1A1D6D4700D5A86B /* Supporting Files */,
 				091489E11CF6986900482D82 /* IterableAPITests.m */,
+				9284CA73206DCA6C00404B74 /* IterableAPIResponseTests.m */,
 				091489E71CF6AC1800482D82 /* CommerceItemTests.m */,
 				09CCB9311D07BA04003EB75D /* IterableNotificationMetadataTests.m */,
 				1608832C1F83EED500318578 /* IterableInAppNotificationTests.m */,
@@ -499,6 +502,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9284CA74206DCA6C00404B74 /* IterableAPIResponseTests.m in Sources */,
 				091489E21CF6986900482D82 /* IterableAPITests.m in Sources */,
 				09CCB9321D07BA04003EB75D /* IterableNotificationMetadataTests.m in Sources */,
 				1608832D1F83EED500318578 /* IterableInAppNotificationTests.m in Sources */,
@@ -626,6 +630,7 @@
 				PROVISIONING_PROFILE = "26e1c0ad-a6ae-4309-9346-38c31fdcb1b0";
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "\"${PROJECT_DIR}/Pods\"/** \"${PROJECT_DIR}/Pods\"/**";
 			};
 			name = Debug;
 		};
@@ -643,6 +648,7 @@
 				PROVISIONING_PROFILE = "26e1c0ad-a6ae-4309-9346-38c31fdcb1b0";
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "\"${PROJECT_DIR}/Pods\"/** \"${PROJECT_DIR}/Pods\"/**";
 			};
 			name = Release;
 		};

--- a/Iterable-iOS-SDKTests/IterableAPIResponseTests.m
+++ b/Iterable-iOS-SDKTests/IterableAPIResponseTests.m
@@ -1,0 +1,160 @@
+//
+//  IterableAPIResponseTests.m
+//  Iterable-iOS-SDKTests
+//
+//  Created by Victor Babenko on 3/29/18.
+//  Copyright © 2018 Iterable. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "IterableAPI.h"
+#import "OHHTTPStubs.h"
+#import "OHPathHelpers.h"
+
+@interface IterableAPI (ResponseTest)
+- (NSURLRequest *)createRequestForAction:(NSString *)action withArgs:(NSDictionary *)args;
+- (void)sendRequest:(NSURLRequest *)request onSuccess:(void (^)(NSDictionary *))onSuccess onFailure:(void (^)(NSString *, NSData *))onFailure;
+@end
+
+@interface IterableAPIResponseTests : XCTestCase
+
+@end
+
+@implementation IterableAPIResponseTests
+
+- (void)setUp {
+    [super setUp];
+    [IterableAPI sharedInstanceWithApiKey:@"" andEmail:@"" launchOptions:nil];
+}
+
+- (void)tearDown {
+    [OHHTTPStubs removeAllStubs];
+    [super tearDown];
+}
+
+- (NSDictionary *)defaultResponseHeaders {
+    return @{@"Content-Type":@"application/json"};
+}
+
+- (void)stubAnyRequestReturningStatusCode:(int)statusCode data:(NSData *)data {
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+        return [OHHTTPStubsResponse responseWithData:data statusCode:statusCode headers:self.defaultResponseHeaders];
+    }];
+}
+
+- (void)stubAnyRequestReturningStatusCode:(int)statusCode json:(NSDictionary *)json {
+    NSError *error = nil;
+    NSData *jsonResponseData = [NSJSONSerialization dataWithJSONObject:json
+                                                               options:0 error:&error];
+    [self stubAnyRequestReturningStatusCode:statusCode data:jsonResponseData];
+}
+
+- (void)testResponseCode200 {
+    NSDictionary *responseData = @{@"key":@"value"};
+    [self stubAnyRequestReturningStatusCode:200 json:responseData];
+    
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"onSuccess is called"];
+    
+    NSURLRequest *request = [[IterableAPI sharedInstance] createRequestForAction:@"" withArgs:@{}];
+    [[IterableAPI sharedInstance] sendRequest:request onSuccess:^(NSDictionary * _Nonnull data) {
+        [expectation fulfill];
+        XCTAssert([data isEqualToDictionary:responseData]);
+    } onFailure:nil];
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testResponseCode200WithNoData {
+    [self stubAnyRequestReturningStatusCode:200 data:nil];
+    
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"onFailure is called"];
+    
+    NSURLRequest *request = [[IterableAPI sharedInstance] createRequestForAction:@"" withArgs:@{}];
+    [[IterableAPI sharedInstance] sendRequest:request onSuccess:nil onFailure:^(NSString * _Nonnull reason, NSData * _Nullable data) {
+        [expectation fulfill];
+        XCTAssertEqual(reason, @"No data received");
+    }];
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testResponseCode200WithInvalidJson {
+    [self stubAnyRequestReturningStatusCode:200 data:[@"{'''}}" dataUsingEncoding:NSUTF8StringEncoding]];
+    
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"onFailure is called"];
+    
+    NSURLRequest *request = [[IterableAPI sharedInstance] createRequestForAction:@"" withArgs:@{}];
+    [[IterableAPI sharedInstance] sendRequest:request onSuccess:nil onFailure:^(NSString * _Nonnull reason, NSData * _Nullable data) {
+        [expectation fulfill];
+        XCTAssert([reason containsString:@"Could not parse json"]);
+    }];
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testResponseCode400WithoutMessage {
+    [self stubAnyRequestReturningStatusCode:400 json:@{}];
+    
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"onFailure is called"];
+    
+    NSURLRequest *request = [[IterableAPI sharedInstance] createRequestForAction:@"" withArgs:@{}];
+    [[IterableAPI sharedInstance] sendRequest:request onSuccess:nil onFailure:^(NSString * _Nonnull reason, NSData * _Nullable data) {
+        [expectation fulfill];
+        XCTAssert([reason containsString:@"Invalid Request"]);
+    }];
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testResponseCode400WithMessage {
+    [self stubAnyRequestReturningStatusCode:400 json:@{@"msg":@"Test error"}];
+    
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"onFailure is called"];
+    
+    NSURLRequest *request = [[IterableAPI sharedInstance] createRequestForAction:@"" withArgs:@{}];
+    [[IterableAPI sharedInstance] sendRequest:request onSuccess:nil onFailure:^(NSString * _Nonnull reason, NSData * _Nullable data) {
+        [expectation fulfill];
+        XCTAssertEqualObjects(reason, @"Test error");
+    }];
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testResponseCode401 {
+    [self stubAnyRequestReturningStatusCode:401 json:@{}];
+    
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"onFailure is called"];
+    
+    NSURLRequest *request = [[IterableAPI sharedInstance] createRequestForAction:@"" withArgs:@{}];
+    [[IterableAPI sharedInstance] sendRequest:request onSuccess:nil onFailure:^(NSString * _Nonnull reason, NSData * _Nullable data) {
+        [expectation fulfill];
+        XCTAssertEqual(reason, @"Invalid API Key");
+    }];
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testResponseCode500 {
+    [self stubAnyRequestReturningStatusCode:500 json:@{}];
+    
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"onFailure is called"];
+    
+    NSURLRequest *request = [[IterableAPI sharedInstance] createRequestForAction:@"" withArgs:@{}];
+    [[IterableAPI sharedInstance] sendRequest:request onSuccess:nil onFailure:^(NSString * _Nonnull reason, NSData * _Nullable data) {
+        [expectation fulfill];
+        XCTAssertEqual(reason, @"Internal Server Error");
+    }];
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testNon200ResponseCode {
+    [self stubAnyRequestReturningStatusCode:302 json:@{}];
+    
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"onFailure is called"];
+    
+    NSURLRequest *request = [[IterableAPI sharedInstance] createRequestForAction:@"" withArgs:@{}];
+    [[IterableAPI sharedInstance] sendRequest:request onSuccess:nil onFailure:^(NSString * _Nonnull reason, NSData * _Nullable data) {
+        [expectation fulfill];
+        XCTAssert([reason containsString:@"Received non-200 response"]);
+    }];
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+@end

--- a/Iterable-iOS-SDKTests/IterableAPIResponseTests.m
+++ b/Iterable-iOS-SDKTests/IterableAPIResponseTests.m
@@ -12,6 +12,8 @@
 #import "OHHTTPStubs.h"
 #import "OHPathHelpers.h"
 
+static CGFloat const IterableResponseExpectationTimeout = 1.0;
+
 @interface IterableAPI (ResponseTest)
 - (NSURLRequest *)createRequestForAction:(NSString *)action withArgs:(NSDictionary *)args;
 - (void)sendRequest:(NSURLRequest *)request onSuccess:(void (^)(NSDictionary *))onSuccess onFailure:(void (^)(NSString *, NSData *))onFailure;
@@ -63,7 +65,7 @@
         [expectation fulfill];
         XCTAssert([data isEqualToDictionary:responseData]);
     } onFailure:nil];
-    [self waitForExpectations:@[expectation] timeout:1.0];
+    [self waitForExpectations:@[expectation] timeout:IterableResponseExpectationTimeout];
 }
 
 - (void)testResponseCode200WithNoData {
@@ -76,7 +78,7 @@
         [expectation fulfill];
         XCTAssertEqual(reason, @"No data received");
     }];
-    [self waitForExpectations:@[expectation] timeout:1.0];
+    [self waitForExpectations:@[expectation] timeout:IterableResponseExpectationTimeout];
 }
 
 - (void)testResponseCode200WithInvalidJson {
@@ -89,7 +91,7 @@
         [expectation fulfill];
         XCTAssert([reason containsString:@"Could not parse json"]);
     }];
-    [self waitForExpectations:@[expectation] timeout:1.0];
+    [self waitForExpectations:@[expectation] timeout:IterableResponseExpectationTimeout];
 }
 
 - (void)testResponseCode400WithoutMessage {
@@ -102,7 +104,7 @@
         [expectation fulfill];
         XCTAssert([reason containsString:@"Invalid Request"]);
     }];
-    [self waitForExpectations:@[expectation] timeout:1.0];
+    [self waitForExpectations:@[expectation] timeout:IterableResponseExpectationTimeout];
 }
 
 - (void)testResponseCode400WithMessage {
@@ -115,7 +117,7 @@
         [expectation fulfill];
         XCTAssertEqualObjects(reason, @"Test error");
     }];
-    [self waitForExpectations:@[expectation] timeout:1.0];
+    [self waitForExpectations:@[expectation] timeout:IterableResponseExpectationTimeout];
 }
 
 - (void)testResponseCode401 {
@@ -128,7 +130,7 @@
         [expectation fulfill];
         XCTAssertEqual(reason, @"Invalid API Key");
     }];
-    [self waitForExpectations:@[expectation] timeout:1.0];
+    [self waitForExpectations:@[expectation] timeout:IterableResponseExpectationTimeout];
 }
 
 - (void)testResponseCode500 {
@@ -141,7 +143,7 @@
         [expectation fulfill];
         XCTAssertEqual(reason, @"Internal Server Error");
     }];
-    [self waitForExpectations:@[expectation] timeout:1.0];
+    [self waitForExpectations:@[expectation] timeout:IterableResponseExpectationTimeout];
 }
 
 - (void)testNon200ResponseCode {
@@ -154,7 +156,7 @@
         [expectation fulfill];
         XCTAssert([reason containsString:@"Received non-200 response"]);
     }];
-    [self waitForExpectations:@[expectation] timeout:1.0];
+    [self waitForExpectations:@[expectation] timeout:IterableResponseExpectationTimeout];
 }
 
 @end

--- a/Podfile
+++ b/Podfile
@@ -8,4 +8,5 @@ end
 
 target 'Iterable-iOS-SDKTests' do
     shared_pods
+    pod 'OHHTTPStubs'
 end


### PR DESCRIPTION
Handle 4xx and 5xx response codes as errors, pass error message to onFailure
Necessary for updateEmail to work properly.