### PR TITLE
[ITBL-5182] Refactor SDK initialization

### DIFF
--- a/Iterable-iOS-SDK.xcodeproj/project.pbxproj
+++ b/Iterable-iOS-SDK.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		929330912099449F00DAE180 /* IterableAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 9293308F2099449F00DAE180 /* IterableAction.m */; };
 		92C6325C208FF7AA00A7C216 /* IterableAppIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 92C6325A208FF7AA00A7C216 /* IterableAppIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		92C6325D208FF7AA00A7C216 /* IterableAppIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 92C6325B208FF7AA00A7C216 /* IterableAppIntegration.m */; };
+		92F03EEC20D899CE00C3BFCA /* IterableConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 92F03EEA20D899CE00C3BFCA /* IterableConfig.h */; };
+		92F03EED20D899CE00C3BFCA /* IterableConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 92F03EEB20D899CE00C3BFCA /* IterableConfig.m */; };
 		92FB47C020995A0F00DA94DC /* IterableActionRunner.h in Headers */ = {isa = PBXBuildFile; fileRef = 92FB47BE20995A0F00DA94DC /* IterableActionRunner.h */; };
 		92FB47C120995A0F00DA94DC /* IterableActionRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 92FB47BF20995A0F00DA94DC /* IterableActionRunner.m */; };
 		934790CB297DB001AB6F035E /* libPods-Iterable-iOS-SDKTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 558AF668BE59E5C06930892D /* libPods-Iterable-iOS-SDKTests.a */; };
@@ -73,6 +75,9 @@
 		AC60AB4920BDD4DC00BF6BEC /* IterableUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = AC60AB4720BDD4DC00BF6BEC /* IterableUtil.m */; };
 		AC60AB4B20BDDD5100BF6BEC /* IterableUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AC60AB4A20BDDD5100BF6BEC /* IterableUtilTests.m */; };
 		E95160B3683E5A47EC313472 /* IterableAppIntegration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E9516F6B446F6E9AB537C83F /* IterableAppIntegration+Private.h */; };
+		E951624B2D970B91EE110E56 /* IterableAPI+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = E95162E0F83DDB6177F24360 /* IterableAPI+Internal.h */; };
+		E9516B4E1A6D7B8CB1314D1F /* IterableAPI+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = E9516BD2E9DDA6AE024F6A63 /* IterableAPI+Deprecated.h */; };
+		E9516D3401091CA4D87B10B9 /* IterableAPI+Deprecated.m in Sources */ = {isa = PBXBuildFile; fileRef = E9516D87A090ED58BED61C6B /* IterableAPI+Deprecated.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -176,6 +181,8 @@
 		9293308F2099449F00DAE180 /* IterableAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IterableAction.m; sourceTree = "<group>"; };
 		92C6325A208FF7AA00A7C216 /* IterableAppIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IterableAppIntegration.h; sourceTree = "<group>"; };
 		92C6325B208FF7AA00A7C216 /* IterableAppIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IterableAppIntegration.m; sourceTree = "<group>"; };
+		92F03EEA20D899CE00C3BFCA /* IterableConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IterableConfig.h; sourceTree = "<group>"; };
+		92F03EEB20D899CE00C3BFCA /* IterableConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IterableConfig.m; sourceTree = "<group>"; };
 		92FB47BE20995A0F00DA94DC /* IterableActionRunner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IterableActionRunner.h; sourceTree = "<group>"; };
 		92FB47BF20995A0F00DA94DC /* IterableActionRunner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IterableActionRunner.m; sourceTree = "<group>"; };
 		AC60AB4620BDD4DC00BF6BEC /* IterableUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IterableUtil.h; sourceTree = "<group>"; };
@@ -183,7 +190,10 @@
 		AC60AB4A20BDDD5100BF6BEC /* IterableUtilTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IterableUtilTests.m; sourceTree = "<group>"; };
 		BE5CCE23DD4BB53759B5D427 /* Pods-Iterable-iOS-SDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Iterable-iOS-SDK.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Iterable-iOS-SDK/Pods-Iterable-iOS-SDK.debug.xcconfig"; sourceTree = "<group>"; };
 		DAB696718A4F07CC09FB5CB1 /* Pods-Iterable-iOS-SDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Iterable-iOS-SDKTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Iterable-iOS-SDKTests/Pods-Iterable-iOS-SDKTests.release.xcconfig"; sourceTree = "<group>"; };
+		E95162E0F83DDB6177F24360 /* IterableAPI+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IterableAPI+Internal.h"; sourceTree = "<group>"; };
 		E95162E4972E90805BB61534 /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = file.yml; path = .travis.yml; sourceTree = "<group>"; };
+		E9516BD2E9DDA6AE024F6A63 /* IterableAPI+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IterableAPI+Deprecated.h"; sourceTree = "<group>"; };
+		E9516D87A090ED58BED61C6B /* IterableAPI+Deprecated.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IterableAPI+Deprecated.m"; sourceTree = "<group>"; };
 		E9516F6B446F6E9AB537C83F /* IterableAppIntegration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IterableAppIntegration+Private.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -269,6 +279,9 @@
 				6804B8651AC10426000A126B /* CommerceItem.h */,
 				093734251A1D6E8800C950B6 /* IterableAPI.h */,
 				093734261A1D701F00C950B6 /* IterableAPI.m */,
+				E95162E0F83DDB6177F24360 /* IterableAPI+Internal.h */,
+				E9516D87A090ED58BED61C6B /* IterableAPI+Deprecated.m */,
+				E9516BD2E9DDA6AE024F6A63 /* IterableAPI+Deprecated.h */,
 				094995451A85880A0047E59B /* NSData+Conversion.h */,
 				094995461A8588400047E59B /* NSData+Conversion.m */,
 				0995DBDB1CFFF70800D50F19 /* IterableLogging.h */,
@@ -286,6 +299,8 @@
 				926B33E320B7A091004DD7CE /* IterableAttributionInfo.m */,
 				AC60AB4620BDD4DC00BF6BEC /* IterableUtil.h */,
 				AC60AB4720BDD4DC00BF6BEC /* IterableUtil.m */,
+				92F03EEA20D899CE00C3BFCA /* IterableConfig.h */,
+				92F03EEB20D899CE00C3BFCA /* IterableConfig.m */,
 			);
 			path = "Iterable-iOS-SDK";
 			sourceTree = "<group>";
@@ -402,6 +417,7 @@
 				92C6325C208FF7AA00A7C216 /* IterableAppIntegration.h in Headers */,
 				161D98BC20236BC700E91846 /* IterableDeeplinkManager.h in Headers */,
 				0937342E1A1D99C000C950B6 /* IterableAPI.h in Headers */,
+				92F03EEC20D899CE00C3BFCA /* IterableConfig.h in Headers */,
 				92FB47C020995A0F00DA94DC /* IterableActionRunner.h in Headers */,
 				68E32EF61AC21D37000CEBE1 /* CommerceItem.h in Headers */,
 				093028D21D1B942100E7CFBE /* IterableNotificationMetadata.h in Headers */,
@@ -413,6 +429,8 @@
 				926B33E420B7A091004DD7CE /* IterableAttributionInfo.h in Headers */,
 				E95160B3683E5A47EC313472 /* IterableAppIntegration+Private.h in Headers */,
 				AC60AB4820BDD4DC00BF6BEC /* IterableUtil.h in Headers */,
+				E9516B4E1A6D7B8CB1314D1F /* IterableAPI+Deprecated.h in Headers */,
+				E951624B2D970B91EE110E56 /* IterableAPI+Internal.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -438,7 +456,6 @@
 				09C0FBF91A1D6D4700D5A86B /* CopyFiles */,
 				0937342D1A1D99BB00C950B6 /* Headers */,
 				092302A31CF6455A004EA265 /* ShellScript */,
-				8F897BDABF58966C088F94AF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -457,8 +474,6 @@
 				09C0FC021A1D6D4700D5A86B /* Sources */,
 				09C0FC031A1D6D4700D5A86B /* Frameworks */,
 				09C0FC041A1D6D4700D5A86B /* Resources */,
-				0D4C767C5C672D1D9C760D48 /* [CP] Embed Pods Frameworks */,
-				6F2BAB400D026ADDE1329DB1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -645,51 +660,6 @@
 			shellPath = /bin/sh;
 			shellScript = "# based on https://www.raywenderlich.com/65964/create-a-framework-for-ios and https://github.com/jverkoey/iOS-Framework#static_library_target\n# also, need to explicitly add armv7s to target architectures; see also: http://stackoverflow.com/questions/28270582/building-ios-framework-missing-architecture-armv7s-and-x86-64-on-fat-file\n\nset -o errexit\nset +o nounset\n# Avoid recursively calling this script.\nif [[ $ITBL_MASTER_SCRIPT_RUNNING ]]; then\nexit 0\nfi\nset -o nounset\nexport ITBL_MASTER_SCRIPT_RUNNING=1\n\nITBL_TARGET_NAME=${PROJECT_NAME}\nITBL_EXECUTABLE_PATH=\"lib${ITBL_TARGET_NAME}.a\"\nITBL_WRAPPER_NAME=\"${ITBL_TARGET_NAME}.framework\"\n\n# The following conditionals come from\n# https://github.com/kstenerud/iOS-Universal-Framework\n\nif [[ \"$SDK_NAME\" =~ ([A-Za-z]+) ]]\nthen\nITBL_SDK_PLATFORM=${BASH_REMATCH[1]}\nelse\necho \"Could not find platform name from SDK_NAME: $SDK_NAME\"\nexit 1\nfi\n\nif [[ \"$SDK_NAME\" =~ ([0-9]+.*$) ]]\nthen\nITBL_SDK_VERSION=${BASH_REMATCH[1]}\nelse\necho \"Could not find sdk version from SDK_NAME: $SDK_NAME\"\nexit 1\nfi\n\n# Build for the simulator architecture\necho \"Building static library: workspace=${PROJECT_DIR}/${PROJECT_NAME}.xcworkspace, scheme=${ITBL_TARGET_NAME}, platform=iphonesimulator, destination='platform=iOS Simulator,name=iPad'\"\n# iPhone5 is the last one on armv7s, iPhone6+ is on armv7\nxcrun xcodebuild ONLY_ACTIVE_ARCH=NO -workspace \"${PROJECT_DIR}/${PROJECT_NAME}.xcworkspace\" -scheme \"${ITBL_TARGET_NAME}\" -configuration \"${CONFIGURATION}\" -sdk iphonesimulator -destination \"platform=iOS Simulator,name=iPhone 6\" BUILD_DIR=\"${BUILD_DIR}\" OBJROOT=\"${OBJROOT}\" BUILD_ROOT=\"${BUILD_ROOT}\" SYMROOT=\"${SYMROOT}\" $ACTION\n\n# Build for real devices\necho \"Building static library: workspace=${PROJECT_DIR}/${PROJECT_NAME}.xcworkspace, scheme=${ITBL_TARGET_NAME}, platform=iphoneos, sdk version=${ITBL_SDK_VERSION}\"\nxcrun xcodebuild ONLY_ACTIVE_ARCH=NO -workspace \"${PROJECT_DIR}/${PROJECT_NAME}.xcworkspace\" -scheme \"${ITBL_TARGET_NAME}\" -configuration \"${CONFIGURATION}\" -sdk iphoneos${ITBL_SDK_VERSION} BUILD_DIR=\"${BUILD_DIR}\" OBJROOT=\"${OBJROOT}\" BUILD_ROOT=\"${BUILD_ROOT}\" SYMROOT=\"${SYMROOT}\" $ACTION\n\necho \"Done building architectures. Cleaning up previous artifacts...\"\n\nDESTINATION_UNIVERSAL_DIR=\"${PROJECT_DIR}/Artifacts/\"\nrm -r \"${DESTINATION_UNIVERSAL_DIR}\"\nmkdir -p \"${DESTINATION_UNIVERSAL_DIR}\"\n\necho \"Done cleaning up artifacts. Running lipo...\"\n\n# Smash the two static libraries into one fat binary and store it in the .framework\nxcrun lipo -create \"${BUILD_DIR}/${CONFIGURATION}-iphonesimulator/${ITBL_EXECUTABLE_PATH}\" \"${BUILD_DIR}/${CONFIGURATION}-iphoneos/${ITBL_EXECUTABLE_PATH}\" -output \"${DESTINATION_UNIVERSAL_DIR}/${ITBL_EXECUTABLE_PATH}\"\n\necho \"Done creating fat file, now copying public headers\"\ncp -r \"${TARGET_BUILD_DIR}/include\" \"${DESTINATION_UNIVERSAL_DIR}/\"\n";
 		};
-		0D4C767C5C672D1D9C760D48 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Iterable-iOS-SDKTests/Pods-Iterable-iOS-SDKTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6F2BAB400D026ADDE1329DB1 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Iterable-iOS-SDKTests/Pods-Iterable-iOS-SDKTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8F897BDABF58966C088F94AF /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Iterable-iOS-SDK/Pods-Iterable-iOS-SDK-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		9AE5129658339C152ECDBC56 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -733,6 +703,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92F03EED20D899CE00C3BFCA /* IterableConfig.m in Sources */,
 				09CCB9301D07A7EA003EB75D /* IterableNotificationMetadata.m in Sources */,
 				16513DDF1D89EECC00C205B3 /* IterableInAppManager.m in Sources */,
 				094995471A8588400047E59B /* NSData+Conversion.m in Sources */,
@@ -747,6 +718,7 @@
 				16E02BAD1E035EA400644C15 /* IterableConstants.m in Sources */,
 				0995DBDD1CFFF7FE00D50F19 /* IterableLogging.m in Sources */,
 				926B33E520B7A091004DD7CE /* IterableAttributionInfo.m in Sources */,
+				E9516D3401091CA4D87B10B9 /* IterableAPI+Deprecated.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1035,6 +1007,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iterable.IterableAppExtensions;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1075,6 +1048,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iterable.IterableAppExtensions;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/Iterable-iOS-SDK/IterableAPI+Deprecated.h
+++ b/Iterable-iOS-SDK/IterableAPI+Deprecated.h
@@ -1,0 +1,128 @@
+//
+// Created by Victor Babenko on 6/18/18.
+// Copyright (c) 2018 Iterable. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "IterableAPI.h"
+
+@interface IterableAPI (Deprecated)
+
+/////////////////////////////////
+/// @name Creating an IterableAPI
+/////////////////////////////////
+
+/*!
+ @method
+
+ @abstract Initializes Iterable with launchOptions
+
+ @param apiKey                  your Iterable apiKey
+ @param email                   the email of the user logged in
+ @param launchOptions           launchOptions from application:didFinishLaunchingWithOptions or custom launchOptions
+ @param useCustomLaunchOptions  whether or not to use the custom launchOption without the UIApplicationLaunchOptionsRemoteNotificationKey
+
+ @return an instance of IterableAPI
+ */
+- (instancetype) initWithApiKey:(NSString *)apiKey andEmail:(NSString *)email launchOptions:(nullable NSDictionary *)launchOptions useCustomLaunchOptions:(BOOL)useCustomLaunchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+
+/*!
+ @method
+
+ @abstract Initializes Iterable with just an API key and email, but no launchOptions
+
+ @param apiKey   your Iterable apiKey
+ @param userId   the userId of the user logged in
+
+ @return an instance of IterableAPI
+ */
+- (instancetype) initWithApiKey:(NSString *)apiKey andUserId:(NSString *) userId __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+
+/*!
+ @method
+
+ @abstract Initializes Iterable with launchOptions
+
+ @param apiKey          your Iterable apiKey
+ @param userId          the userId of the user logged in
+ @param launchOptions   launchOptions from application:didFinishLaunchingWithOptions
+
+ @return an instance of IterableAPI
+ */
+- (instancetype) initWithApiKey:(NSString *)apiKey andUserId:(NSString *)userId launchOptions:(nullable NSDictionary *)launchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+
+/*!
+ @method
+
+ @abstract Initializes Iterable with launchOptions
+
+ @param apiKey          your Iterable apiKey
+ @param userId          the userId of the user logged in
+ @param launchOptions   launchOptions from application:didFinishLaunchingWithOptions or custom launchOptions
+ @param useCustomLaunchOptions  whether or not to use the custom launchOption without the UIApplicationLaunchOptionsRemoteNotificationKey
+
+ @return an instance of IterableAPI
+ */
+- (instancetype) initWithApiKey:(NSString *)apiKey andUserId:(NSString *)userId launchOptions:(nullable NSDictionary *)launchOptions useCustomLaunchOptions:(BOOL)useCustomLaunchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+
+/*!
+ @method
+
+ @abstract Initializes a shared instance of Iterable with launchOptions
+
+ @discussion The sharedInstanceWithApiKey with email is preferred over userId.
+ This method will set up a singleton instance of the `IterableAPI` class for
+ you using the given project API key. When you want to make calls to Iterable
+ elsewhere in your code, you can use `sharedInstance`. If launchOptions is there and
+ the app was launched from a remote push notification, we will track a pushOpen.
+
+ @param apiKey          your Iterable apiKey
+ @param userId           the userId of the user logged in
+ @param launchOptions   launchOptions from application:didFinishLaunchingWithOptions
+
+ @return an instance of IterableAPI
+ */
++ (IterableAPI *) sharedInstanceWithApiKey:(NSString *)apiKey andUserId:(NSString *)userId launchOptions:(nullable NSDictionary *)launchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+
+/*!
+ @method
+
+ @abstract Initializes a shared instance of Iterable with launchOptions
+
+ @discussion The sharedInstanceWithApiKey with email is preferred over userId.
+ This method will set up a singleton instance of the `IterableAPI` class for
+ you using the given project API key. When you want to make calls to Iterable
+ elsewhere in your code, you can use `sharedInstance`. If launchOptions is there and
+ the app was launched from a remote push notification, we will track a pushOpen.
+
+ @param apiKey          your Iterable apiKey
+ @param email           the email of the user logged in
+ @param launchOptions   launchOptions from application:didFinishLaunchingWithOptions
+
+ @return an instance of IterableAPI
+ */
++ (IterableAPI *) sharedInstanceWithApiKey:(NSString *)apiKey andEmail:(NSString *)email launchOptions:(nullable NSDictionary *)launchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+
+/*!
+ @method
+
+ @abstract Get the previously instantiated singleton instance of the API
+
+ @discussion Must be initialized with `sharedInstanceWithApiKey:` before
+ calling this class method.
+
+ @return the existing `IterableAPI` instance
+
+ @warning `sharedInstance` will return `nil` if called before calling `sharedInstanceWithApiKey:andEmail:launchOptions:`
+ */
++ (nullable IterableAPI *)sharedInstance;
+
+/*!
+ @method
+
+ @abstract Sets the previously instantiated singleton instance of the API to nil
+
+ */
++ (void)clearSharedInstance __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:config:] to initialize the SDK and setUserEmail:/setUserId: to set the user email/id.");
+
+@end

--- a/Iterable-iOS-SDK/IterableAPI+Deprecated.h
+++ b/Iterable-iOS-SDK/IterableAPI+Deprecated.h
@@ -6,6 +6,8 @@
 #import <Foundation/Foundation.h>
 #import "IterableAPI.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface IterableAPI (Deprecated)
 
 /////////////////////////////////
@@ -24,7 +26,11 @@
 
  @return an instance of IterableAPI
  */
-- (instancetype) initWithApiKey:(NSString *)apiKey andEmail:(NSString *)email launchOptions:(nullable NSDictionary *)launchOptions useCustomLaunchOptions:(BOOL)useCustomLaunchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+- (instancetype) initWithApiKey:(NSString *)apiKey
+                       andEmail:(NSString *)email
+                  launchOptions:(nullable NSDictionary *)launchOptions
+         useCustomLaunchOptions:(BOOL)useCustomLaunchOptions
+__deprecated_msg("Use [IterableAPI initializeWithApiKey:launchOptions:] instead.");
 
 /*!
  @method
@@ -36,7 +42,9 @@
 
  @return an instance of IterableAPI
  */
-- (instancetype) initWithApiKey:(NSString *)apiKey andUserId:(NSString *) userId __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+- (instancetype) initWithApiKey:(NSString *)apiKey
+                      andUserId:(NSString *)userId
+__deprecated_msg("Use [IterableAPI initializeWithApiKey:launchOptions:] instead.");
 
 /*!
  @method
@@ -49,7 +57,10 @@
 
  @return an instance of IterableAPI
  */
-- (instancetype) initWithApiKey:(NSString *)apiKey andUserId:(NSString *)userId launchOptions:(nullable NSDictionary *)launchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+- (instancetype) initWithApiKey:(NSString *)apiKey
+                      andUserId:(NSString *)userId
+                  launchOptions:(nullable NSDictionary *)launchOptions
+__deprecated_msg("Use [IterableAPI initializeWithApiKey:launchOptions:] instead.");
 
 /*!
  @method
@@ -63,7 +74,11 @@
 
  @return an instance of IterableAPI
  */
-- (instancetype) initWithApiKey:(NSString *)apiKey andUserId:(NSString *)userId launchOptions:(nullable NSDictionary *)launchOptions useCustomLaunchOptions:(BOOL)useCustomLaunchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
+- (instancetype) initWithApiKey:(NSString *)apiKey
+                      andUserId:(NSString *)userId
+                  launchOptions:(nullable NSDictionary *)launchOptions
+         useCustomLaunchOptions:(BOOL)useCustomLaunchOptions
+__deprecated_msg("Use [IterableAPI initializeWithApiKey:launchOptions:] instead.");
 
 /*!
  @method
@@ -82,7 +97,10 @@
 
  @return an instance of IterableAPI
  */
-+ (IterableAPI *) sharedInstanceWithApiKey:(NSString *)apiKey andUserId:(NSString *)userId launchOptions:(nullable NSDictionary *)launchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
++ (IterableAPI *) sharedInstanceWithApiKey:(NSString *)apiKey
+                                 andUserId:(NSString *)userId
+                             launchOptions:(nullable NSDictionary *)launchOptions
+__deprecated_msg("Use [IterableAPI initializeWithApiKey:launchOptions:] instead.");
 
 /*!
  @method
@@ -101,7 +119,10 @@
 
  @return an instance of IterableAPI
  */
-+ (IterableAPI *) sharedInstanceWithApiKey:(NSString *)apiKey andEmail:(NSString *)email launchOptions:(nullable NSDictionary *)launchOptions __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:] instead.");
++ (IterableAPI *) sharedInstanceWithApiKey:(NSString *)apiKey
+                                  andEmail:(NSString *)email
+                             launchOptions:(nullable NSDictionary *)launchOptions
+__deprecated_msg("Use [IterableAPI initializeWithApiKey:launchOptions:] instead.");
 
 /*!
  @method
@@ -123,6 +144,46 @@
  @abstract Sets the previously instantiated singleton instance of the API to nil
 
  */
-+ (void)clearSharedInstance __deprecated_msg("Use [IterableAPI startWithApiKey:launchOptions:config:] to initialize the SDK and setUserEmail:/setUserId: to set the user email/id.");
++ (void)clearSharedInstance
+__deprecated_msg("Use [IterableAPI initializeWithApiKey:launchOptions:config:] to initialize the SDK and setUserEmail:/setUserId: to set the user email/id.");
+
+/*!
+ @method
+
+ @abstract Register this device's token with Iterable
+
+ @param token       The token representing this device/application pair, obtained from
+                    `application:didRegisterForRemoteNotificationsWithDeviceToken`
+                    after registering for remote notifications
+ @param appName     The application name, as configured in Iterable during set up of the push integration
+ @param pushServicePlatform     The PushServicePlatform to use for this device; dictates whether to register this token in the sandbox or production environment
+
+ @see PushServicePlatform
+
+ */
+- (void)registerToken:(NSData *)token appName:(NSString *)appName pushServicePlatform:(PushServicePlatform)pushServicePlatform
+__deprecated_msg("Use [IterableAPI initializeWithApiKey:launchOptions:config:] with push integration names in IterableConfig to initialize the SDK and registerToken: to register device tokens.");
+
+/*!
+ @method
+
+ @abstract Register this device's token with Iterable with custom completion blocks
+
+ @param token                   The token representing this device/application pair, obtained from
+                                `application:didRegisterForRemoteNotificationsWithDeviceToken`
+                                after registering for remote notifications
+ @param appName                 The application name, as configured in Iterable during set up of the push integration
+ @param pushServicePlatform     The PushServicePlatform to use for this device; dictates whether to register this token in the sandbox or production environment
+ @param onSuccess               OnSuccessHandler to invoke if token registration is successful
+ @param onFailure               OnFailureHandler to invoke if token registration fails
+
+ @see PushServicePlatform
+ @see OnSuccessHandler
+ @see OnFailureHandler
+ */
+- (void)registerToken:(NSData *)token appName:(NSString *)appName pushServicePlatform:(PushServicePlatform)pushServicePlatform onSuccess:(OnSuccessHandler)onSuccess onFailure:(OnFailureHandler)onFailure
+__deprecated_msg("Use [IterableAPI initializeWithApiKey:launchOptions:config:] with push integration names in IterableConfig to initialize the SDK and registerToken:onSuccess:onFailure to register device tokens.");
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Iterable-iOS-SDK/IterableAPI+Deprecated.m
+++ b/Iterable-iOS-SDK/IterableAPI+Deprecated.m
@@ -1,0 +1,10 @@
+//
+// Created by Victor Babenko on 6/18/18.
+// Copyright (c) 2018 Iterable. All rights reserved.
+//
+
+#import "IterableAPI+Deprecated.h"
+
+
+@implementation IterableAPI (Deprecated)
+@end

--- a/Iterable-iOS-SDK/IterableAPI+Deprecated.m
+++ b/Iterable-iOS-SDK/IterableAPI+Deprecated.m
@@ -4,7 +4,3 @@
 //
 
 #import "IterableAPI+Deprecated.h"
-
-
-@implementation IterableAPI (Deprecated)
-@end

--- a/Iterable-iOS-SDK/IterableAPI+Internal.h
+++ b/Iterable-iOS-SDK/IterableAPI+Internal.h
@@ -8,6 +8,6 @@
 
 @interface IterableAPI (Internal)
 
-@property(nonatomic, readonly) BOOL sdkCompatEnabled;
+@property(nonatomic) BOOL sdkCompatEnabled;
 
 @end

--- a/Iterable-iOS-SDK/IterableAPI+Internal.h
+++ b/Iterable-iOS-SDK/IterableAPI+Internal.h
@@ -1,0 +1,13 @@
+//
+// Created by Victor Babenko on 6/18/18.
+// Copyright (c) 2018 Iterable. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "IterableAPI.h"
+
+@interface IterableAPI (Internal)
+
+@property(nonatomic, readonly) BOOL sdkCompatEnabled;
+
+@end

--- a/Iterable-iOS-SDK/IterableAPI.h
+++ b/Iterable-iOS-SDK/IterableAPI.h
@@ -27,16 +27,6 @@ typedef void (^OnSuccessHandler)(NSDictionary *data);
 typedef void (^OnFailureHandler)(NSString *reason, NSData *_Nullable data);
 
 /**
- Enum representing push platform; apple push notification service, production vs sandbox
- */
-typedef NS_ENUM(NSInteger, PushServicePlatform) {
-    /** The sandbox push service */
-    APNS_SANDBOX,
-    /** The production push service */
-    APNS
-};
-
-/**
  `IterableAPI` contains all the essential functions for communicating with Iterable's API
  */
 @interface IterableAPI : NSObject
@@ -91,49 +81,46 @@ typedef NS_ENUM(NSInteger, PushServicePlatform) {
 /// @name Setting user email or user id
 /////////////////////////////
 
+/**
+ * Set user email used for API calls
+ * Calling this or `setUserId:` is required before making any API calls.
+ * Note: this clears userId and persists the user email so you only need to call this once when the user logs in.
+ * @param email User email
+ */
 - (void)setEmail:(nullable NSString *)email;
+
+/**
+ * Set user ID used for API calls
+ * Calling this or `setEmail:` is required before making any API calls.
+ * Note: this clears user email and persists the user ID so you only need to call this once when the user logs in.
+ * @param userId User ID
+ */
 - (void)setUserId:(nullable NSString *)userId;
 
 /////////////////////////////
 /// @name Registering a token
 /////////////////////////////
 
-/*!
- @method 
- 
- @abstract Register this device's token with Iterable
-
- @param token       The token representing this device/application pair, obtained from
+/**
+ * Register this device's token with Iterable
+ * Push integration name and platform are read from `IterableConfig`. If platform is set to `AUTO`, it will
+ * read APNS environment from the provisioning profile and use an integration name specified in `IterableConfig`.
+ * @param token The token representing this device/application pair, obtained from
                     `application:didRegisterForRemoteNotificationsWithDeviceToken`
                     after registering for remote notifications
- @param appName     The application name, as configured in Iterable during set up of the push integration
- @param pushServicePlatform     The PushServicePlatform to use for this device; dictates whether to register this token in the sandbox or production environment
- 
- @see PushServicePlatform
- 
  */
-- (void)registerToken:(NSData *)token appName:(NSString *)appName pushServicePlatform:(PushServicePlatform)pushServicePlatform;
-
-/*!
- @method
- 
- @abstract Register this device's token with Iterable with custom completion blocks
- 
- @param token                   The token representing this device/application pair, obtained from
-                                `application:didRegisterForRemoteNotificationsWithDeviceToken`
-                                after registering for remote notifications
- @param appName                 The application name, as configured in Iterable during set up of the push integration
- @param pushServicePlatform     The PushServicePlatform to use for this device; dictates whether to register this token in the sandbox or production environment
- @param onSuccess               OnSuccessHandler to invoke if token registration is successful
- @param onFailure               OnFailureHandler to invoke if token registration fails
- 
- @see PushServicePlatform
- @see OnSuccessHandler
- @see OnFailureHandler
- */
-- (void)registerToken:(NSData *)token appName:(NSString *)appName pushServicePlatform:(PushServicePlatform)pushServicePlatform onSuccess:(OnSuccessHandler)onSuccess onFailure:(OnFailureHandler)onFailure;
-
 - (void)registerToken:(NSData *)token;
+
+/**
+ * Register this device's token with Iterable
+ * Push integration name and platform are read from `IterableConfig`. If platform is set to `AUTO`, it will
+ * read APNS environment from the provisioning profile and use an integration name specified in `IterableConfig`.
+ * @param token The token representing this device/application pair, obtained from
+                    `application:didRegisterForRemoteNotificationsWithDeviceToken`
+                    after registering for remote notifications
+ * @param onSuccess    OnSuccessHandler to invoke if token registration is successful
+ * @param onFailure    OnFailureHandler to invoke if token registration fails
+ */
 - (void)registerToken:(NSData *)token onSuccess:(OnSuccessHandler)onSuccess onFailure:(OnFailureHandler)onFailure;
 
 /////////////////////////////

--- a/Iterable-iOS-SDK/IterableAPI.h
+++ b/Iterable-iOS-SDK/IterableAPI.h
@@ -73,8 +73,25 @@ typedef void (^OnFailureHandler)(NSString *reason, NSData *_Nullable data);
 /// @name Initializing IterableAPI
 /////////////////////////////////
 
+/**
+ * Initializes IterableAPI
+ * This method must be called from UIApplicationDelegate's `application:didFinishLaunchingWithOptions:`
+ *
+ * @note Make sure you also call `setEmail:` or `setUserId:` before making any API calls
+ * @param apiKey Iterable Mobile API key
+ * @param launchOptions launchOptions object passed from `application:didFinishLaunchingWithOptions:`
+ */
 + (void)initializeWithApiKey:(NSString *)apiKey launchOptions:(nullable NSDictionary *)launchOptions;
 
+/**
+ * Initializes IterableAPI
+ * This method must be called from UIApplicationDelegate's `application:didFinishLaunchingWithOptions:`
+ *
+ * @note Make sure you also call `setEmail:` or `setUserId:` before making any API calls
+ * @param apiKey Iterable Mobile API key
+ * @param launchOptions launchOptions object passed from `application:didFinishLaunchingWithOptions:`
+ * @param config `IterableConfig` object holding SDK configuration options
+ */
 + (void)initializeWithApiKey:(NSString *)apiKey launchOptions:(nullable NSDictionary *)launchOptions config:(IterableConfig *)config;
 
 /////////////////////////////
@@ -84,7 +101,8 @@ typedef void (^OnFailureHandler)(NSString *reason, NSData *_Nullable data);
 /**
  * Set user email used for API calls
  * Calling this or `setUserId:` is required before making any API calls.
- * Note: this clears userId and persists the user email so you only need to call this once when the user logs in.
+ *
+ * @note This clears userId and persists the user email so you only need to call this once when the user logs in.
  * @param email User email
  */
 - (void)setEmail:(nullable NSString *)email;
@@ -92,7 +110,8 @@ typedef void (^OnFailureHandler)(NSString *reason, NSData *_Nullable data);
 /**
  * Set user ID used for API calls
  * Calling this or `setEmail:` is required before making any API calls.
- * Note: this clears user email and persists the user ID so you only need to call this once when the user logs in.
+ *
+ * @note This clears user email and persists the user ID so you only need to call this once when the user logs in.
  * @param userId User ID
  */
 - (void)setUserId:(nullable NSString *)userId;

--- a/Iterable-iOS-SDK/IterableAPI.h
+++ b/Iterable-iOS-SDK/IterableAPI.h
@@ -58,12 +58,12 @@ typedef NS_ENUM(NSInteger, PushServicePlatform) {
 /**
  The email of the logged in user that this IterableAPI is using
  */
-@property(nonatomic, copy) NSString *email;
+@property(nonatomic, readonly, copy) NSString *email;
 
 /**
  The userId of the logged in user that this IterableAPI is using
  */
-@property(nonatomic, copy) NSString *userId;
+@property(nonatomic, readonly, copy) NSString *userId;
 
 /**
  The hex representation of this device token

--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -29,7 +29,7 @@
 @interface IterableAPI ()
 
 @property(nonatomic, readonly) BOOL initialized;
-@property(nonatomic, readonly) BOOL sdkCompatEnabled;
+@property(nonatomic) BOOL sdkCompatEnabled;
 
 @end
 
@@ -377,9 +377,13 @@ NSCharacterSet* encodedCharacterSet = nil;
         if (useCustomLaunchOptions) {
             [IterableAppIntegration performDefaultNotificationAction:launchOptions api:self];
         } else if (launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey]) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            if (![UIApplication sharedApplication].keyWindow) {
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                    [IterableAppIntegration performDefaultNotificationAction:launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey] api:self];
+                });
+            } else {
                 [IterableAppIntegration performDefaultNotificationAction:launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey] api:self];
-            });
+            }
         }
     }
 }

--- a/Iterable-iOS-SDK/IterableAPI.m
+++ b/Iterable-iOS-SDK/IterableAPI.m
@@ -691,6 +691,7 @@ NSCharacterSet* encodedCharacterSet = nil;
 - (void)registerToken:(NSData *)token {
     if (!self.config) {
         LogError(@"The SDK must be initialized with [IterableAPI initializeWithApiKey:launchOptions:config:] for registerToken: to work.");
+        return;
     }
     [self registerToken:token appName:[self pushIntegrationName] pushServicePlatform:self.config.pushPlatform];
 }
@@ -699,6 +700,7 @@ NSCharacterSet* encodedCharacterSet = nil;
 - (void)registerToken:(NSData *)token onSuccess:(OnSuccessHandler)onSuccess onFailure:(OnFailureHandler)onFailure {
     if (!self.config) {
         LogError(@"The SDK must be initialized with [IterableAPI initializeWithApiKey:launchOptions:config:] for registerToken:onSuccess:onFailure: to work.");
+        return;
     }
     [self registerToken:token appName:[self pushIntegrationName] pushServicePlatform:self.config.pushPlatform onSuccess:onSuccess onFailure:onFailure];
 }
@@ -721,7 +723,15 @@ NSCharacterSet* encodedCharacterSet = nil;
 
     UIDevice *device = [UIDevice currentDevice];
     NSString *psp = [IterableAPI pushServicePlatformToString:pushServicePlatform];
-    
+
+    if (!appName) {
+        LogError(@"registerToken: appName is nil");
+        if (onFailure) {
+            onFailure(@"Not registering device token - appName must not be nil", [[NSData alloc] init]);
+        }
+        return;
+    }
+
     if (!psp) {
         LogError(@"registerToken: invalid pushServicePlatform");
         if (onFailure) {

--- a/Iterable-iOS-SDK/IterableActionRunner.m
+++ b/Iterable-iOS-SDK/IterableActionRunner.m
@@ -8,6 +8,7 @@
 
 #import "IterableActionRunner.h"
 #import "IterableAPI.h"
+#import "IterableAPI+Internal.h"
 #import "IterableLogging.h"
 
 @implementation IterableActionRunner
@@ -28,7 +29,7 @@
         return;
     }
     
-    if ([[IterableAPI sharedInstance].urlDelegate handleIterableURL:url fromAction:action]) {
+    if ([[IterableAPI sharedInstance].config.urlDelegate handleIterableURL:url fromAction:action]) {
         return;
     }
 
@@ -52,7 +53,7 @@
 
 + (void)callCustomActionIfSpecified:(IterableAction *)action {
     if (action.type.length > 0) {
-        [[IterableAPI sharedInstance].customActionDelegate handleIterableCustomAction:action];
+        [[IterableAPI sharedInstance].config.customActionDelegate handleIterableCustomAction:action];
     }
 }
 

--- a/Iterable-iOS-SDK/IterableActionRunner.m
+++ b/Iterable-iOS-SDK/IterableActionRunner.m
@@ -14,6 +14,11 @@
 @implementation IterableActionRunner
 
 + (void)executeAction:(IterableAction *)action {
+    // Do not handle actions and try to open Safari for URLs unless the SDK is initialized with a new init method
+    if ([IterableAPI sharedInstance].sdkCompatEnabled) {
+        return;
+    }
+
     if ([action isOfType:IterableActionTypeOpenUrl]) {
         // Open deeplink, use delegate handler
         [self openURL:[NSURL URLWithString:action.data] action:action];

--- a/Iterable-iOS-SDK/IterableAppIntegration.m
+++ b/Iterable-iOS-SDK/IterableAppIntegration.m
@@ -40,6 +40,12 @@
 
 + (void)performDefaultNotificationAction:(NSDictionary *)userInfo api:(IterableAPI *)api {
     NSDictionary *itbl = userInfo[ITBL_PAYLOAD_METADATA];
+
+    // Ignore the notification if we've already processed it from launchOptions while initializing the SDK
+    if ([userInfo isEqualToDictionary:[IterableAPI sharedInstance].lastPushPayload]) {
+        return;
+    }
+
 #ifdef DEBUG
     if (itbl[ITBL_PAYLOAD_DEFAULT_ACTION] == nil && itbl[ITBL_PAYLOAD_ACTION_BUTTONS] == nil) {
         itbl = userInfo;
@@ -66,6 +72,14 @@
     LogDebug(@"IterableAPI: didReceiveNotificationResponse: %@", response);
     NSDictionary *userInfo = response.notification.request.content.userInfo;
     NSDictionary *itbl = userInfo[ITBL_PAYLOAD_METADATA];
+    
+    // Ignore the notification if we've already processed it from launchOptions while initializing the SDK
+    if ([userInfo isEqualToDictionary:[IterableAPI sharedInstance].lastPushPayload]) {
+        if (completionHandler) {
+            completionHandler();
+        }
+        return;
+    }
 
 #ifdef DEBUG
     if (itbl[ITBL_PAYLOAD_DEFAULT_ACTION] == nil && itbl[ITBL_PAYLOAD_ACTION_BUTTONS] == nil) {

--- a/Iterable-iOS-SDK/IterableConfig.h
+++ b/Iterable-iOS-SDK/IterableConfig.h
@@ -40,6 +40,18 @@
 @end
 
 /**
+ Enum representing push platform; apple push notification service, production vs sandbox
+ */
+typedef NS_ENUM(NSInteger, PushServicePlatform) {
+    /** The sandbox push service */
+            APNS_SANDBOX,
+    /** The production push service */
+            APNS,
+    /** Detect automatically */
+            AUTO
+};
+
+/**
  * Iterable SDK configuration object.
  * Create and pass this object during SDK initialization.
  */
@@ -49,7 +61,20 @@
  * Push integration name – used for token registration.
  * Make sure the name of this integration matches the one set up in Iterable console.
  */
-@property(nonatomic, copy) NSString *pushIntegration;
+@property(nonatomic, copy) NSString *pushIntegrationName;
+
+/**
+ * Push integration name for development builds – used for token registration.
+ * Make sure the name of this integration matches the one set up in Iterable console.
+ */
+@property(nonatomic, copy) NSString *sandboxPushIntegrationName;
+
+/**
+ * APNS environment for the current build of the app.
+ * Possible values: `APNS_SANDBOX`, `APNS_SANDBOX`, `AUTO`
+ * Defaults to `AUTO` and detects the APNS environment automatically
+ */
+@property(nonatomic, assign) PushServicePlatform pushPlatform;
 
 /**
  * Custom URL handler to override openUrl actions

--- a/Iterable-iOS-SDK/IterableConfig.h
+++ b/Iterable-iOS-SDK/IterableConfig.h
@@ -1,0 +1,64 @@
+//
+//  IterableConfig.h
+//  Iterable-iOS-SDK
+//
+//  Created by Victor Babenko on 6/18/18.
+//  Copyright © 2018 Iterable. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class IterableAction;
+
+/**
+ * Custom URL handling delegate
+ */
+@protocol IterableURLDelegate <NSObject>
+
+/**
+ * Callback called for a deeplink action. Return YES to override default behavior
+ * @param url     Deeplink URL
+ * @param action  Original openUrl Action object
+ * @return Boolean value. Return YES if the URL was handled to override default behavior.
+ */
+- (BOOL)handleIterableURL:(NSURL *)url fromAction:(IterableAction *)action;
+
+@end
+
+/**
+ * Custom action handling delegate
+ */
+@protocol IterableCustomActionDelegate <NSObject>
+
+/**
+ * Callback called for custom actions from push notifications
+ * @param action  `IterableAction` object containing action payload
+ * @return Boolean value. Reserved for future use.
+ */
+- (BOOL)handleIterableCustomAction:(IterableAction *)action;
+
+@end
+
+/**
+ * Iterable SDK configuration object.
+ * Create and pass this object during SDK initialization.
+ */
+@interface IterableConfig : NSObject
+
+/**
+ * Push integration name – used for token registration.
+ * Make sure the name of this integration matches the one set up in Iterable console.
+ */
+@property(nonatomic, copy) NSString *pushIntegration;
+
+/**
+ * Custom URL handler to override openUrl actions
+ */
+@property(nonatomic) id<IterableURLDelegate> urlDelegate;
+
+/**
+ * Action handler for custom actions
+ */
+@property(nonatomic) id<IterableCustomActionDelegate> customActionDelegate;
+
+@end

--- a/Iterable-iOS-SDK/IterableConfig.m
+++ b/Iterable-iOS-SDK/IterableConfig.m
@@ -1,0 +1,16 @@
+//
+//  IterableConfig.m
+//  Iterable-iOS-SDK
+//
+//  Created by Victor Babenko on 6/18/18.
+//  Copyright © 2018 Iterable. All rights reserved.
+//
+
+#import "IterableConfig.h"
+#import "IterableAction.h"
+
+@implementation IterableConfig
+
+
+
+@end

--- a/Iterable-iOS-SDK/IterableConfig.m
+++ b/Iterable-iOS-SDK/IterableConfig.m
@@ -11,6 +11,12 @@
 
 @implementation IterableConfig
 
-
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _pushPlatform = AUTO;
+    }
+    return self;
+}
 
 @end

--- a/Iterable-iOS-SDK/IterableConstants.h
+++ b/Iterable-iOS-SDK/IterableConstants.h
@@ -95,6 +95,8 @@ extern NSString *const ITBL_DEVICE_USER_INTERFACE;
 #define ITBL_USER_DEFAULTS_PAYLOAD_EXPIRATION_HOURS 24
 #define ITBL_USER_DEFAULTS_ATTRIBUTION_INFO_KEY @"itbl_attribution_info_key"
 #define ITBL_USER_DEFAULTS_ATTRIBUTION_INFO_EXPIRATION_HOURS 24
+#define ITBL_USER_DEFAULTS_EMAIL_KEY @"itbl_email"
+#define ITBL_USER_DEFAULTS_USERID_KEY @"itbl_userid"
 
 //Action Buttons
 #define ITBL_BUTTON_IDENTIFIER @"identifier"
@@ -137,6 +139,5 @@ extern NSString *const ITBL_DEVICE_USER_INTERFACE;
 #define ITERABLE_IN_APP_HTML @"html"
 #define ITERABLE_IN_APP_HREF @"href"
 #define ITERABLE_IN_APP_DISPLAY_SETTINGS @"inAppDisplaySettings"
-
 
 typedef void (^ITEActionBlock)(NSString *);

--- a/Iterable-iOS-SDK/IterableUtil.h
+++ b/Iterable-iOS-SDK/IterableUtil.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface IterableUtil : NSObject
 
 + (NSDate *)currentDate;
++ (BOOL)isSandboxAPNS;
 
 @end
 

--- a/Iterable-iOS-SDKTests/IterableAPITests.m
+++ b/Iterable-iOS-SDKTests/IterableAPITests.m
@@ -309,4 +309,24 @@ NSString *iterableNoRewriteURL = @"http://links.iterable.com/u/60402396fbd5433eb
     [OHHTTPStubs removeAllStubs];
 }
 
+- (void)testEmailUserIdPersistence {
+    IterableAPI.sharedInstance.sdkCompatEnabled = YES;
+    [IterableAPI clearSharedInstance];
+    [IterableAPI initializeWithApiKey:@"apiKey" launchOptions:nil];
+    [[IterableAPI sharedInstance] setEmail:@"test@email.com"];
+    
+    IterableAPI.sharedInstance.sdkCompatEnabled = YES;
+    [IterableAPI clearSharedInstance];
+    [IterableAPI initializeWithApiKey:@"apiKey" launchOptions:nil];
+    XCTAssertEqualObjects([IterableAPI sharedInstance].email, @"test@email.com");
+    XCTAssertNil([IterableAPI sharedInstance].userId);
+    
+    [[IterableAPI sharedInstance] setUserId:@"testUserId"];
+    IterableAPI.sharedInstance.sdkCompatEnabled = YES;
+    [IterableAPI clearSharedInstance];
+    [IterableAPI initializeWithApiKey:@"apiKey" launchOptions:nil];
+    XCTAssertEqualObjects([IterableAPI sharedInstance].userId, @"testUserId");
+    XCTAssertNil([IterableAPI sharedInstance].email);
+}
+
 @end

--- a/Iterable-iOS-SDKTests/IterableAPITests.m
+++ b/Iterable-iOS-SDKTests/IterableAPITests.m
@@ -9,10 +9,13 @@
 #import <XCTest/XCTest.h>
 
 #import <asl.h>
-#import "OHHTTPStubs.h"
+#import <OHHTTPStubs.h>
+#import <OHHTTPStubs/NSURLRequest+HTTPBodyTesting.h>
 
 #import "IterableAPI.h"
+#import "IterableAPI+Internal.h"
 #import "IterableDeeplinkManager.h"
+#import "NSData+Conversion.h"
 
 static CGFloat const IterableNetworkResponseExpectationTimeout = 5.0;
 
@@ -50,13 +53,14 @@ NSString *iterableNoRewriteURL = @"http://links.iterable.com/u/60402396fbd5433eb
 }
 
 - (void)testSdkInitializedWithNil {
-    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
         XCTAssert(false, @"API calls should not be made without an email or userId");
         return YES;
-    } withStubResponse:^OHHTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
-        return [OHHTTPStubsResponse responseWithData:@"" statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithData:[@"" dataUsingEncoding:kCFStringEncodingUTF8] statusCode:200 headers:@{@"Content-Type":@"application/json"}];
     }];
-    
+
+    IterableAPI.sharedInstance.sdkCompatEnabled = YES;
     [IterableAPI clearSharedInstance];
     [IterableAPI sharedInstanceWithApiKey:@"" andEmail:nil launchOptions:nil];
     [[IterableAPI sharedInstance] track:@"testEvent"];
@@ -275,6 +279,34 @@ NSString *iterableNoRewriteURL = @"http://links.iterable.com/u/60402396fbd5433eb
     
     NSString* nilSet = [[IterableAPI sharedInstance] encodeURLParam:nil];
     XCTAssertEqual(nilSet, nil);
+}
+
+- (void)testRegisterToken {
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"Request is sent"];
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        [expectation fulfill];
+        NSDictionary *json = [NSJSONSerialization
+                              JSONObjectWithData:request.OHHTTPStubs_HTTPBody
+                              options:0 error:nil];
+        XCTAssertEqualObjects(json[@"email"], @"user@example.com");
+        XCTAssertEqualObjects(json[@"device"][@"applicationName"], @"pushIntegration");
+        XCTAssertEqualObjects(json[@"device"][@"platform"], @"APNS_SANDBOX");
+        XCTAssertEqualObjects(json[@"device"][@"token"], [[@"token" dataUsingEncoding:kCFStringEncodingUTF8] ITEHexadecimalString]);
+        return [OHHTTPStubsResponse responseWithData:[@"" dataUsingEncoding:kCFStringEncodingUTF8] statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    IterableAPI.sharedInstance.sdkCompatEnabled = YES;
+    [IterableAPI clearSharedInstance];
+    IterableConfig *config = [[IterableConfig alloc] init];
+    config.pushIntegrationName = @"pushIntegration";
+    [IterableAPI initializeWithApiKey:@"apiKey" launchOptions:nil config:config];
+    [[IterableAPI sharedInstance] setEmail:@"user@example.com"];
+    [[IterableAPI sharedInstance] registerToken:[@"token" dataUsingEncoding:kCFStringEncodingUTF8]];
+    
+    [self waitForExpectations:@[expectation] timeout:1.0];
+    [OHHTTPStubs removeAllStubs];
 }
 
 @end

--- a/Iterable-iOS-SDKTests/IterableActionRunnerTests.m
+++ b/Iterable-iOS-SDKTests/IterableActionRunnerTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
 #import "IterableAPI.h"
+#import "IterableAPI+Internal.h"
 #import "IterableActionRunner.h"
 
 @interface IterableActionRunnerTests : XCTestCase
@@ -19,7 +20,8 @@
 
 - (void)setUp {
     [super setUp];
-    [IterableAPI sharedInstanceWithApiKey:@"" andEmail:@"" launchOptions:nil];
+    IterableAPI.sharedInstance.sdkCompatEnabled = YES;
+    [IterableAPI clearSharedInstance];
 }
 
 - (void)tearDown {
@@ -30,7 +32,11 @@
 - (void)testUrlOpenAction {
     id urlDelegateMock = OCMProtocolMock(@protocol(IterableURLDelegate));
     id applicationMock = OCMPartialMock([UIApplication sharedApplication]);
-    IterableAPI.sharedInstance.urlDelegate = urlDelegateMock;
+    
+    IterableConfig *config = [[IterableConfig alloc] init];
+    config.urlDelegate = urlDelegateMock;
+    [IterableAPI initializeWithApiKey:@"" launchOptions:nil config:config];
+    
     IterableAction *action = [IterableAction actionFromDictionary:@{ @"type": @"openUrl", @"data": @"https://example.com" }];
     [IterableActionRunner executeAction:action];
     
@@ -52,7 +58,11 @@
         OCMReject([applicationMock openURL:[OCMArg any]]);
     }
     OCMStub([urlDelegateMock handleIterableURL:[OCMArg any] fromAction:[OCMArg any]]).andReturn(YES);
-    IterableAPI.sharedInstance.urlDelegate = urlDelegateMock;
+    
+    IterableConfig *config = [[IterableConfig alloc] init];
+    config.urlDelegate = urlDelegateMock;
+    [IterableAPI initializeWithApiKey:@"" launchOptions:nil config:config];
+    
     IterableAction *action = [IterableAction actionFromDictionary:@{ @"type": @"openUrl", @"data": @"https://example.com" }];
     [IterableActionRunner executeAction:action];
     
@@ -61,7 +71,11 @@
 
 - (void)testCustomAction {
     id customActionDelegateMock = OCMProtocolMock(@protocol(IterableCustomActionDelegate));
-    IterableAPI.sharedInstance.customActionDelegate = customActionDelegateMock;
+    
+    IterableConfig *config = [[IterableConfig alloc] init];
+    config.customActionDelegate = customActionDelegateMock;
+    [IterableAPI initializeWithApiKey:@"" launchOptions:nil config:config];
+    
     IterableAction *action = [IterableAction actionFromDictionary:@{ @"type": @"customActionName" }];
     [IterableActionRunner executeAction:action];
     

--- a/Iterable-iOS-SDKTests/IterableNotificationResponseTests.m
+++ b/Iterable-iOS-SDKTests/IterableNotificationResponseTests.m
@@ -12,6 +12,7 @@
 #import "IterableActionRunner.h"
 #import "IterableUtil.h"
 #import "IterableAPI.h"
+#import "IterableAPI+Internal.h"
 
 @interface IterableNotificationResponseTests : XCTestCase
 
@@ -21,6 +22,8 @@
 
 - (void)setUp {
     [super setUp];
+    IterableAPI.sharedInstance.sdkCompatEnabled = YES;
+    [IterableAPI clearSharedInstance];
     [IterableAPI sharedInstanceWithApiKey:@"" andEmail:@"" launchOptions:nil];
 }
 


### PR DESCRIPTION
- Make IterableAPI a signleton that is only initalized once, decouple setEmail/setUserId from SDK initialization
- Persist email/userId so the app only has to call it when the user logs in or logs out
- Detect APNS environment automatically, by parsing the provisioning profile
- Deprecate old methods
- Make sure we only switch to the new behavior (like opening push links in Safari by default) when the SDK is initialized with the new method